### PR TITLE
feat: implement agent profile system (Issue #2)

### DIFF
--- a/config/agent_profiles.yaml
+++ b/config/agent_profiles.yaml
@@ -1,0 +1,34 @@
+agents:
+  - name: PM
+    role: project_manager
+    responsibilities:
+      - 프로젝트 일정 관리
+      - 진행 상황 보고
+      - 리스크 식별
+    expertise:
+      - 일정 계획
+      - 자원 관리
+    phase_triggers:
+      status_check: "프로젝트 현황을 보고하세요"
+
+  - name: TechLead
+    role: tech_lead
+    responsibilities:
+      - 기술 의사결정
+      - 아키텍처 설계
+      - 코드 리뷰
+    expertise:
+      - 시스템 설계
+      - 성능 최적화
+    phase_triggers:
+      issue_resolution: "기술적 해결 방안을 제시하세요"
+
+  - name: Designer
+    role: designer
+    responsibilities:
+      - UI/UX 설계
+      - 사용자 경험 개선
+    expertise:
+      - 인터페이스 디자인
+      - 사용성 테스트
+    phase_triggers: {}

--- a/tests/core/__init__.py
+++ b/tests/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core tests package"""

--- a/tests/core/test_profile.py
+++ b/tests/core/test_profile.py
@@ -1,0 +1,27 @@
+import pytest
+from thetable.core.profile import AgentProfile, load_agent_profiles
+
+
+def test_agent_profile_creation():
+    """Agent Profile 생성 테스트"""
+    profile = AgentProfile(
+        name="PM",
+        role="project_manager",
+        responsibilities=["프로젝트 일정 관리", "진행 상황 보고"],
+        expertise=["일정 계획", "자원 관리"],
+        phase_triggers={"status_check": "자동 발언"}
+    )
+
+    assert profile.name == "PM"
+    assert profile.role == "project_manager"
+    assert len(profile.responsibilities) == 2
+    assert "status_check" in profile.phase_triggers
+
+
+def test_load_agent_profiles_from_yaml():
+    """YAML에서 Agent Profile 로드 테스트"""
+    profiles = load_agent_profiles("config/agent_profiles.yaml")
+
+    assert "PM" in profiles
+    assert "TechLead" in profiles
+    assert profiles["PM"].role == "project_manager"

--- a/thetable/core/__init__.py
+++ b/thetable/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core components"""

--- a/thetable/core/profile.py
+++ b/thetable/core/profile.py
@@ -1,0 +1,30 @@
+"""Agent profile system"""
+from typing import Dict, List
+from pydantic import BaseModel
+import yaml
+
+
+class AgentProfile(BaseModel):
+    """Agent의 역할, 책임, 전문성 정의"""
+    name: str
+    role: str
+    responsibilities: List[str]
+    expertise: List[str]
+    phase_triggers: Dict[str, str] = {}
+
+    def matches_phase(self, phase: str) -> bool:
+        """특정 phase에서 자동 발언해야 하는지 확인"""
+        return phase in self.phase_triggers
+
+
+def load_agent_profiles(yaml_path: str) -> Dict[str, AgentProfile]:
+    """YAML 파일에서 Agent Profile 로드"""
+    with open(yaml_path, 'r', encoding='utf-8') as f:
+        data = yaml.safe_load(f)
+
+    profiles = {}
+    for agent_data in data.get('agents', []):
+        profile = AgentProfile(**agent_data)
+        profiles[profile.name] = profile
+
+    return profiles


### PR DESCRIPTION
## 변경 사항
- AgentProfile 클래스 구현 (Pydantic BaseModel)
- YAML에서 profile 로드하는 함수
- config/agent_profiles.yaml 생성 (PM, TechLead, Designer)
- Phase별 자동 발언 트리거 기능

## 구현 내용
- `thetable/core/profile.py`: AgentProfile, load_agent_profiles
- `config/agent_profiles.yaml`: 3개 Agent 정의
- `tests/core/test_profile.py`: 2개 테스트

## TDD 사이클
✅ Red: 테스트 작성
✅ Green: 구현 완료 (2/2 테스트 통과)
✅ Commit: 변경사항 커밋

## 테스트
```bash
uv run pytest tests/core/test_profile.py -v
```

Closes #2