### PR TITLE
feat: define MeetingState with TypedDict (Issue #3)

### DIFF
--- a/tests/graph/__init__.py
+++ b/tests/graph/__init__.py
@@ -1,0 +1,1 @@
+"""Graph tests"""

--- a/tests/graph/test_state.py
+++ b/tests/graph/test_state.py
@@ -1,0 +1,25 @@
+"""Tests for MeetingState definition"""
+from thetable.graph.state import MeetingState, AgentInfo
+
+
+def test_agent_info_creation():
+    """AgentInfo 생성 테스트"""
+    agent = AgentInfo(
+        name="PM",
+        role="project_manager",
+        profile_key="PM"
+    )
+
+    assert agent.name == "PM"
+    assert agent.role == "project_manager"
+
+
+def test_meeting_state_structure():
+    """MeetingState 구조 테스트"""
+    from typing import get_type_hints
+    hints = get_type_hints(MeetingState)
+
+    assert 'messages' in hints
+    assert 'current_phase' in hints
+    assert 'agents' in hints
+    assert 'next_speaker' in hints

--- a/thetable/graph/__init__.py
+++ b/thetable/graph/__init__.py
@@ -1,0 +1,1 @@
+"""Graph components for workflow"""

--- a/thetable/graph/state.py
+++ b/thetable/graph/state.py
@@ -1,0 +1,41 @@
+"""Meeting state definition"""
+from typing import Annotated, List, Optional, Dict, Any
+from typing_extensions import TypedDict
+from langgraph.graph.message import add_messages
+from langchain_core.messages import BaseMessage
+from pydantic import BaseModel
+
+
+class AgentInfo(BaseModel):
+    """Agent 기본 정보"""
+    name: str
+    role: str
+    profile_key: str  # agent_profiles.yaml의 키
+
+
+class MeetingState(TypedDict):
+    """회의 상태"""
+
+    # 대화 히스토리 (자동 누적)
+    messages: Annotated[List[BaseMessage], add_messages]
+
+    # Phase 관리
+    current_phase: str  # "opening", "status_check", "issue_resolution", "closing"
+    phase_history: List[str]  # Phase 전환 이력
+
+    # Agent 관리
+    agents: List[AgentInfo]
+    next_speaker: Optional[str]  # 다음 발언자 이름
+    current_task: Optional[str]  # Supervisor가 부여한 task
+
+    # 발언 추적
+    speaker_counts: Dict[str, int]
+    pending_mentions: List[str]
+
+    # Phase 제약
+    phase_required_speakers: Dict[str, List[str]]  # Phase별 필수 발언자
+    phase_goals: Dict[str, str]  # Phase별 목표
+
+    # 메타데이터
+    start_time: float
+    phase_start_time: float


### PR DESCRIPTION
## 변경 사항
- AgentInfo 클래스 구현 (Pydantic BaseModel)
- MeetingState TypedDict 정의
- add_messages reducer 통합

## 구현 내용
- `thetable/graph/state.py`: AgentInfo, MeetingState
- `tests/graph/test_state.py`: 상태 구조 테스트

## MeetingState 필드
- messages (add_messages reducer)
- Phase 관리 (current_phase, phase_history)
- Agent 관리 (agents, next_speaker, current_task)
- 발언 추적 (speaker_counts, pending_mentions)
- Phase 제약 (phase_required_speakers, phase_goals)

## TDD 사이클
✅ Red: 테스트 작성
✅ Green: 구현 완료 (2/2 테스트 통과)
✅ Commit: 변경사항 커밋

Closes #3