### PR TITLE
feat: 토큰 길이 제한 처리 및 안건 데이터 모델 개선 (#66)

### DIFF
--- a/config/agent_profiles.yaml
+++ b/config/agent_profiles.yaml
@@ -52,7 +52,7 @@ agents:
       target_repository: "yaklevel/thetable"
       # default_branch: "main"
       additional_instructions: |
-        (IMPORTANT) 도구를 적극적으로 사용하세요
+        (IMPORTANT) 도구를 적극적으로 사용하세요.
 
   - name: TechLead
     role: tech_lead
@@ -71,7 +71,9 @@ agents:
     metadata:
       target_repository: "yaklevel/thetable"
       additional_instructions: |
-        (IMPORTANT) 도구를 적극적으로 사용하세요
+        (IMPORTANT) 도구를 적극적으로 사용하세요.
+      # additional_instructions: |
+      #   Always base your contributions on real data when tools are available.
       # review_required: true
     # agents:
     #   - name: Backend

--- a/thetable/agents/base_agent.py
+++ b/thetable/agents/base_agent.py
@@ -5,6 +5,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, ToolMessage
 from langchain_openai import ChatOpenAI
+from openai import LengthFinishReasonError
 
 from thetable.config import get_settings
 from thetable.core.profile import AgentProfile
@@ -31,8 +32,9 @@ class BaseAgent:
         """기본 LLM 초기화"""
         settings = get_settings()
         kwargs = {
-            "model": settings.llm_model,
-            "temperature": settings.llm_temperature,
+            "model": settings.llm_main_model,
+            "temperature": settings.llm_main_temperature,
+            "max_tokens": settings.llm_main_max_tokens,
         }
         if settings.openai_base_url:
             kwargs["base_url"] = settings.openai_base_url
@@ -124,16 +126,24 @@ Always base your contributions on real data when tools are available.
         logger.info(f"[{self.name}] 🔧 MCP tool-calling 모드 활성화 ({len(self._mcp_tools)}개 도구)")
         tool_messages = list(messages)  # 복사
         iteration = 0
-        max_iterations = 10
+        max_iterations = 50
 
         while iteration < max_iterations:
             iteration += 1
             logger.debug(f"[{self.name}] 🔄 Tool-calling 루프 #{iteration}")
 
-            response = await self._llm.bind_tools(self._mcp_tools).ainvoke(
-                tool_messages,
-                config=config
-            )
+            try:
+                response = await self._llm.bind_tools(self._mcp_tools).ainvoke(
+                    tool_messages,
+                    config=config
+                )
+            except LengthFinishReasonError as e:
+                logger.error(f"[{self.name}] ❌ 토큰 길이 제한 도달: {e}")
+                return AIMessage(
+                    content=f"({self.name}: 응답이 너무 길어 생성을 중단했습니다. 더 간결한 질문으로 다시 시도해주세요.)",
+                    name=self.name
+                )
+            
             tool_messages.append(response)
 
             if not response.tool_calls:

--- a/thetable/config/settings.py
+++ b/thetable/config/settings.py
@@ -19,10 +19,12 @@ class Settings(BaseSettings):
     # Main LLM (회의 에이전트 응답 생성)
     llm_main_model: str = "gpt-4o-mini"
     llm_main_temperature: float = 0.7
+    llm_main_max_tokens: int = 4096  # 응답 최대 토큰 (기본값)
     
     # Task LLM (작은 작업: 멘션 추출, 종료 감지, 안건 분석)
     llm_task_model: str = "gpt-4o-mini"  # 나중에 gpt-3.5-turbo 등으로 변경 가능
     llm_task_temperature: float = 0.0    # 일관된 결과 위해 낮게
+    llm_task_max_tokens: int = 2048  # Task LLM은 더 짧은 응답
 
     # LLM 연결 설정
     llm_timeout: float = 60.0  # 초 단위

--- a/thetable/graph/agenda_manager.py
+++ b/thetable/graph/agenda_manager.py
@@ -7,16 +7,32 @@ from langchain_core.messages import BaseMessage, SystemMessage, HumanMessage
 from pydantic import BaseModel, Field
 
 
+class AgendaItem(BaseModel):
+    """개별 안건 항목"""
+    title: str = Field(description="안건 제목")
+    description: str = Field(default="", description="안건 설명")
+    status: str = Field(default="pending", description="상태: pending, in_progress, completed, deferred")
+    required_speakers: List[str] = Field(default_factory=list, description="필수 발언자 목록")
+    owner: Optional[str] = Field(default=None, description="담당자")
+    decision: Optional[str] = Field(default=None, description="결정사항")
+    start_time: Optional[float] = Field(default=None, description="시작 시간")
+    end_time: Optional[float] = Field(default=None, description="종료 시간")
+
+
 class AgendaExtractionResult(BaseModel):
     """안건 추출 결과"""
-    items: List[dict] = Field(
+    items: List[AgendaItem] = Field(
         default_factory=list,
-        description="업데이트된 안건 리스트 (dict 형태)"
+        description="업데이트된 안건 리스트"
     )
     changes_summary: Optional[str] = Field(
         default=None,
         description="변경사항 요약 (디버깅용)"
     )
+
+    def items_as_dicts(self) -> List[dict]:
+        """items를 dict 리스트로 변환 (워크플로우 호환용)"""
+        return [item.model_dump() for item in self.items]
 
 
 async def extract_agenda_updates(
@@ -126,7 +142,9 @@ async def extract_agenda_updates(
         except Exception as inner_e:
             # 최종 fallback: 기존 안건 유지
             print(f"⚠️ 안건 추출 실패 (유지): {e}, {inner_e}")
+            # dict를 AgendaItem으로 변환
+            fallback_items = [AgendaItem(**item) for item in current_items]
             return AgendaExtractionResult(
-                items=current_items,
+                items=fallback_items,
                 changes_summary=f"추출 실패, 기존 안건 유지: {str(e)}"
             )

--- a/thetable/graph/workflow.py
+++ b/thetable/graph/workflow.py
@@ -270,7 +270,7 @@ async def process_response(state: MeetingState, model, valid_speakers: list[str]
         )
 
         # 업데이트된 안건으로 교체 (타임스탬프 보존)
-        new_agendas_from_llm = agenda_result.items
+        new_agendas_from_llm = agenda_result.items_as_dicts()
 
         # 기존 타임스탬프 복원 (LLM이 제거했을 수 있음)
         for i, new_agenda in enumerate(new_agendas_from_llm):
@@ -388,6 +388,7 @@ def create_meeting_workflow(
         main_kwargs = {
             "model": settings.llm_main_model,
             "temperature": settings.llm_main_temperature,
+            "max_tokens": settings.llm_main_max_tokens,
             "api_key": settings.openai_api_key,
             "streaming": True,  # 스트리밍 활성화
             "timeout": settings.llm_timeout,
@@ -402,6 +403,7 @@ def create_meeting_workflow(
         task_kwargs = {
             "model": settings.llm_task_model,
             "temperature": settings.llm_task_temperature,
+            "max_tokens": settings.llm_task_max_tokens,
             "api_key": settings.openai_api_key,
             "timeout": settings.llm_timeout,
             "max_retries": settings.llm_max_retries,


### PR DESCRIPTION
## Summary
- LLM 응답 토큰 길이 제한 설정 추가로 안정성 향상
- AgendaItem Pydantic 모델 도입으로 타입 안전성 강화
- Tool-calling 반복 횟수 증가로 복잡한 도구 체인 지원

## Changes
### 토큰 길이 제한 처리
- `llm_main_max_tokens` (4096), `llm_task_max_tokens` (2048) 설정 추가
- `LengthFinishReasonError` 예외 처리 구현
- 토큰 한도 초과 시 사용자 친화적 메시지 반환

### 안건 데이터 모델 개선
- `AgendaItem` Pydantic 모델 도입 (기존 dict 기반에서 전환)
- 타입 안전성과 코드 가독성 향상
- `items_as_dicts()` 메서드로 기존 워크플로우 호환성 유지

### 에이전트 도구 사용 최적화
- Tool-calling 최대 반복 횟수 10 → 50으로 증가
- 복잡한 도구 체인 호출 시나리오 지원 강화

## Test plan
- [ ] LLM 응답이 토큰 한도를 초과하는 시나리오 테스트
- [ ] 안건 생성/업데이트가 새 모델로 정상 작동하는지 확인
- [ ] 복잡한 도구 체인 호출 시나리오 검증
- [ ] 기존 회의 워크플로우 회귀 테스트

## Related Issues
Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)