### PR TITLE
refactor: init_chat_model을 ChatOpenAI로 통일 (#79)

### DIFF
--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -6,7 +6,7 @@ import time
 from typing import List, Dict
 
 from langchain_core.messages import HumanMessage, AIMessage
-from langchain.chat_models import init_chat_model
+from langchain_openai import ChatOpenAI
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
@@ -21,14 +21,15 @@ from thetable.config import get_settings
 
 console = Console()
 
-async def benchmark_model(model_name: str, provider: str, base_url: str = None, api_key: str = None):
-    console.print(f"[bold blue]Starting benchmark for {model_name} ({provider})[/bold blue]")
-    
+async def benchmark_model(model_name: str, base_url: str = None, api_key: str = None):
+    console.print(f"[bold blue]Starting benchmark for {model_name}[/bold blue]")
+
     settings = get_settings()
-    
+
     # Init Model
     try:
         kwargs = {
+            "model": model_name,
             "temperature": 0.0,
             "max_tokens": 1024,
         }
@@ -36,14 +37,10 @@ async def benchmark_model(model_name: str, provider: str, base_url: str = None, 
             kwargs["base_url"] = base_url
         if api_key:
             kwargs["api_key"] = api_key
-        elif provider == "openai":
+        else:
             kwargs["api_key"] = settings.openai_api_key
 
-        model = init_chat_model(
-            model=model_name,
-            model_provider=provider,
-            **kwargs
-        )
+        model = ChatOpenAI(**kwargs)
         console.print(f"✅ Model initialized: {model.__class__.__name__}")
     except Exception as e:
         console.print(f"[bold red]❌ Model initialization failed: {e}[/bold red]")
@@ -114,10 +111,9 @@ async def benchmark_model(model_name: str, provider: str, base_url: str = None, 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="LLM Benchmark for TheTable")
     parser.add_argument("--model", type=str, default="gpt-4o-mini", help="Model name")
-    parser.add_argument("--provider", type=str, default="openai", help="Model provider (openai, anthropic, ollama, etc)")
     parser.add_argument("--base-url", type=str, help="Custom Base URL")
     parser.add_argument("--api-key", type=str, help="API Key")
-    
+
     args = parser.parse_args()
-    
-    asyncio.run(benchmark_model(args.model, args.provider, args.base_url, args.api_key))
+
+    asyncio.run(benchmark_model(args.model, args.base_url, args.api_key))

--- a/thetable/config/settings.py
+++ b/thetable/config/settings.py
@@ -17,13 +17,11 @@ class Settings(BaseSettings):
     openai_base_url: Optional[str] = None  # 선택적 (기본: OpenAI 공식 엔드포인트)
     
     # Main LLM (회의 에이전트 응답 생성)
-    llm_main_provider: str = "openai"  # openai, anthropic, google_genai, ollama, etc.
     llm_main_model: str = "gpt-4o-mini"
     llm_main_temperature: float = 0.7
     llm_main_max_tokens: int = 4096  # 응답 최대 토큰 (기본값)
     
     # Task LLM (작은 작업: 멘션 추출, 종료 감지, 안건 분석)
-    llm_task_provider: str = "openai"
     llm_task_model: str = "gpt-4o-mini"  # 나중에 gpt-3.5-turbo 등으로 변경 가능
     llm_task_temperature: float = 0.0    # 일관된 결과 위해 낮게
     llm_task_max_tokens: int = 2048  # Task LLM은 더 짧은 응답

--- a/thetable/graph/agenda_manager.py
+++ b/thetable/graph/agenda_manager.py
@@ -109,12 +109,10 @@ async def extract_agenda_updates(
 
     try:
         # 1차 시도: 구조화된 출력
-        kwargs = {}
-        # OpenAI 모델인 경우 function_calling 모드 명시 (스키마 호환성 위함)
-        if "OpenAI" in llm.__class__.__name__:
-            kwargs["method"] = "function_calling"
-            
-        structured_llm = llm.with_structured_output(AgendaExtractionResult, **kwargs)
+        structured_llm = llm.with_structured_output(
+            AgendaExtractionResult,
+            method="function_calling",
+        )
         result = await structured_llm.ainvoke([
             SystemMessage(content=system_prompt),
             HumanMessage(content="위 대화를 분석하여 안건 목록을 업데이트해주세요.")

--- a/thetable/graph/workflow.py
+++ b/thetable/graph/workflow.py
@@ -10,7 +10,7 @@
 import asyncio
 from pathlib import Path
 from langchain_core.messages import HumanMessage
-from langchain.chat_models import init_chat_model
+from langchain_openai import ChatOpenAI
 from langgraph.graph import StateGraph, END
 from prompt_toolkit import prompt as pt_prompt
 from loguru import logger
@@ -408,8 +408,8 @@ def condition_router(state: MeetingState) -> str:
 
 def create_meeting_workflow(
     profiles_path: str = "config/agent_profiles.yaml",
-    main_model = None,  # BaseChatModel
-    task_model = None,  # BaseChatModel
+    main_model = None,  # ChatOpenAI
+    task_model = None,  # ChatOpenAI
     mcp_tools: dict[str, list] = None
 ):
     """안건 기반 회의 워크플로우 생성
@@ -425,10 +425,11 @@ def create_meeting_workflow(
     """
 
     settings = get_settings()
-    
+
     # Main model (에이전트 응답 생성용)
     if main_model is None:
-        main_kwargs = {
+        kwargs = {
+            "model": settings.llm_main_model,
             "temperature": settings.llm_main_temperature,
             "max_tokens": settings.llm_main_max_tokens,
             "streaming": True,
@@ -436,34 +437,25 @@ def create_meeting_workflow(
             "max_retries": settings.llm_max_retries,
         }
         if settings.openai_api_key:
-            main_kwargs["api_key"] = settings.openai_api_key
+            kwargs["api_key"] = settings.openai_api_key
         if settings.openai_base_url:
-            main_kwargs["base_url"] = settings.openai_base_url
-            
-        main_model = init_chat_model(
-            model=settings.llm_main_model,
-            model_provider=settings.llm_main_provider,
-            **main_kwargs
-        )
-    
+            kwargs["base_url"] = settings.openai_base_url
+        main_model = ChatOpenAI(**kwargs)
+
     # Task model (유틸리티 작업용)
     if task_model is None:
-        task_kwargs = {
+        kwargs = {
+            "model": settings.llm_task_model,
             "temperature": settings.llm_task_temperature,
             "max_tokens": settings.llm_task_max_tokens,
             "timeout": settings.llm_timeout,
             "max_retries": settings.llm_max_retries,
         }
         if settings.openai_api_key:
-            task_kwargs["api_key"] = settings.openai_api_key
+            kwargs["api_key"] = settings.openai_api_key
         if settings.openai_base_url:
-            task_kwargs["base_url"] = settings.openai_base_url
-            
-        task_model = init_chat_model(
-            model=settings.llm_task_model,
-            model_provider=settings.llm_task_provider,
-            **task_kwargs
-        )
+            kwargs["base_url"] = settings.openai_base_url
+        task_model = ChatOpenAI(**kwargs)
 
     # 1. 프로필 로드
     profiles = load_agent_profiles(profiles_path)


### PR DESCRIPTION
## 개요
OpenAI API 스펙이 업계 표준이므로 `base_url` 변경만으로 대부분의 프로바이더를 지원할 수 있습니다. 
`init_chat_model` + `llm_*_provider` 설정을 제거하고 `ChatOpenAI` + `base_url`로 통일하여 YAGNI 원칙을 준수합니다.

Closes #79

## 주요 변경사항

### 1. Settings 단순화
- ❌ `llm_main_provider`, `llm_task_provider` 필드 제거
- ✅ `openai_api_key`, `openai_base_url`만으로 모든 OpenAI 호환 프로바이더 지원

### 2. Workflow 간소화
- `init_chat_model()` → `ChatOpenAI()` 직접 사용
- 불필요한 헬퍼 함수 없이 명시적 초기화
- 30줄 추가, 46줄 삭제 (순 -16줄)

### 3. 분기 제거
- `agenda_manager.py`: OpenAI 클래스명 런타임 체크 제거
- `benchmark_models.py`: `--provider` 파라미터 제거

## 기술적 세부사항

**YAGNI 원칙 준수**:
- 사용되지 않는 멀티 프로바이더 추상화 제거
- 2번만 사용되는 헬퍼 함수 제거 (직접 초기화가 더 명시적)

**호환성 유지**:
- `base_url` 변경만으로 Groq, Together AI, Ollama, vLLM 등 지원 가능
- 기존 `.env` 파일의 provider 변수는 `extra="ignore"`로 무시됨

## 테스트

✅ **20개 테스트 통과**
- `tests/graph/test_workflow.py`: 12 passed
- `tests/config/test_settings.py`: 8 passed
- 2개 테스트는 기존과 동일하게 스킵 (Mock 업데이트 필요, 별도 이슈화 예정)

## 검증

```bash
# init_chat_model 제거 확인
grep -r "init_chat_model" thetable/ scripts/  # No matches

# provider 관련 코드 제거 확인  
grep -r "llm_.*_provider" thetable/ scripts/  # No matches

# 테스트 실행
uv run pytest tests/ -v  # 20 passed, 2 skipped
```

## 변경 파일
- `thetable/config/settings.py`
- `thetable/graph/workflow.py`
- `thetable/graph/agenda_manager.py`
- `scripts/benchmark_models.py`