### PR TITLE
feat: streaming 모드를 기본값으로 전환

### DIFF
--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -34,3 +34,10 @@ def test_cli_custom_message():
     """커스텀 메시지로 실행 테스트"""
     result = runner.invoke(app, ["--message", "커스텀 회의", "--help"])
     assert result.exit_code == 0
+
+
+def test_cli_no_stream_option():
+    """--no-stream 옵션 존재 확인"""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "--no-stream" in result.stdout

--- a/thetable/interfaces/cli.py
+++ b/thetable/interfaces/cli.py
@@ -93,8 +93,8 @@ def _handle_chat_model_end(event: dict) -> None:
         console.rule(style="dim")
 
 
-def _handle_chain_end(event: dict) -> None:
-    """on_chain_end 이벤트 처리 - pending_speakers 표시"""
+def _handle_chain_end(event: dict, state_ref: dict) -> None:
+    """on_chain_end 이벤트 처리 - pending_speakers 표시 및 상태 누적"""
     tags = event.get("tags", [])
     if "langgraph_node" not in tags:
         return
@@ -115,6 +115,40 @@ def _handle_chain_end(event: dict) -> None:
 
     if pending:
         console.print(f"[dim]다음 발언 예정: {', '.join(pending)}[/dim]")
+
+    # 상태 누적 (요약 테이블용)
+    if "agendas" in output_data:
+        state_ref["agendas"] = output_data["agendas"]
+    if "speaker_counts" in output_data:
+        state_ref["speaker_counts"] = output_data["speaker_counts"]
+
+
+def _print_summary_table(agendas: Optional[List[dict]], speaker_counts: Optional[dict]) -> None:
+    """회의 요약 테이블 출력
+
+    Args:
+        agendas: 안건 리스트 (optional)
+        speaker_counts: 발언 횟수 딕셔너리 (optional)
+    """
+    if not agendas and not speaker_counts:
+        return
+
+    table = Table(title="회의 요약", show_header=True)
+    table.add_column("항목", style="cyan")
+    table.add_column("값", style="yellow")
+
+    # 안건 상태
+    if agendas:
+        completed = sum(1 for a in agendas if a["status"] == "completed")
+        table.add_row("완료된 안건", f"{completed}/{len(agendas)}")
+
+    # 발언 횟수
+    if speaker_counts:
+        for speaker, count in speaker_counts.items():
+            table.add_row(f"{speaker} 발언 횟수", str(count))
+
+    console.print("\n")
+    console.print(table)
 
 
 def format_agenda_panel(
@@ -193,11 +227,10 @@ def main(
         exists=True,
         dir_okay=False,
     ),
-    stream: bool = typer.Option(
+    no_stream: bool = typer.Option(
         False,
-        "--stream",
-        "-s",
-        help="스트리밍 모드 사용 (실시간 출력)",
+        "--no-stream",
+        help="스트리밍 모드 비활성화 (배치 모드 사용)",
     ),
     config: Optional[Path] = typer.Option(
         None,
@@ -247,8 +280,12 @@ def main(
 
         # 다른 옵션과 함께 사용
 
-        thetable --message "회의 시작" --stream -v
+        thetable --message "회의 시작" -v
         thetable --profiles config/custom.yaml
+
+        # 배치 모드 사용 (스트리밍 비활성화)
+
+        thetable --no-stream
     """
     # 버전 출력
     if version:
@@ -257,6 +294,9 @@ def main(
 
     # 로깅 설정
     setup_logging(verbose=verbose, quiet=quiet)
+
+    # 스트리밍 모드 계산 (--no-stream 플래그의 반대)
+    stream = not no_stream
 
     # 설정 로드
     settings = get_settings(config_path=config)
@@ -387,7 +427,9 @@ async def _run_streaming(workflow, state: dict, config: dict) -> None:
     state_ref = {
         "current_speaker": None,
         "prev_agenda_state": None,
-        "start_time": state["start_time"]
+        "start_time": state["start_time"],
+        "agendas": None,
+        "speaker_counts": None,
     }
 
     # 이벤트 핸들러 매핑
@@ -404,10 +446,13 @@ async def _run_streaming(workflow, state: dict, config: dict) -> None:
         handler = event_handlers.get(kind)
         if handler:
             # state_ref를 받는 핸들러와 받지 않는 핸들러 구분
-            if kind in ("on_chain_start", "on_chat_model_start"):
+            if kind in ("on_chain_start", "on_chat_model_start", "on_chain_end"):
                 handler(event, state_ref)
             else:
                 handler(event)
+
+    # 스트리밍 완료 후 요약 테이블 출력
+    _print_summary_table(state_ref.get("agendas"), state_ref.get("speaker_counts"))
 
 
 async def _run_batch(workflow, state: dict, config: dict) -> dict:
@@ -442,25 +487,7 @@ async def _run_batch(workflow, state: dict, config: dict) -> dict:
         console.rule(style="dim")
 
     # 메타 정보 테이블
-    if "agendas" in result or "speaker_counts" in result:
-        table = Table(title="회의 요약", show_header=True)
-        table.add_column("항목", style="cyan")
-        table.add_column("값", style="yellow")
-
-        # 안건 상태
-        if "agendas" in result:
-            agendas = result["agendas"]
-            completed = sum(1 for a in agendas if a["status"] == "completed")
-            table.add_row("완료된 안건", f"{completed}/{len(agendas)}")
-
-        # 발언 횟수
-        if "speaker_counts" in result:
-            counts = result["speaker_counts"]
-            for speaker, count in counts.items():
-                table.add_row(f"{speaker} 발언 횟수", str(count))
-
-        console.print("\n")
-        console.print(table)
+    _print_summary_table(result.get("agendas"), result.get("speaker_counts"))
 
     return result
 


### PR DESCRIPTION
## Summary

TheTable CLI의 기본 동작을 batch 모드에서 streaming 모드로 전환합니다.

## 변경사항

### 🔄 CLI 옵션 변경
- `--stream/-s` → `--no-stream` 플래그로 변경
- **기본 동작**: streaming 모드 (실시간 출력)
- **배치 모드**: `--no-stream` 플래그로 활성화

### ✨ 기능 추가
- Streaming 모드에 회의 요약 테이블 출력 추가
- `_print_summary_table()` 함수로 요약 테이블 로직 공통화
- `_handle_chain_end()` 이벤트 핸들러에서 상태 누적 (`agendas`, `speaker_counts`)

### 🧪 테스트
- `test_cli_no_stream_option()` 테스트 추가
- 모든 기존 테스트 통과 (102 passed, 2 skipped)

## 배경

회의 시스템 특성상 streaming이 더 자연스러운 기본값입니다:

1. **UX 개선**: Batch 모드는 회의 전체가 완료될 때까지 빈 화면을 표시
2. **Human 참여자 지원**: Human 참여자가 있으면 batch 모드는 사실상 작동 불가
3. **기능 동등성**: Batch 모드의 유일한 차별점(요약 테이블)을 streaming 모드에도 제공

## Test Plan

- [x] `uv run thetable --help`로 CLI 옵션 확인
- [x] `uv run pytest`로 기존 테스트 통과 확인 (102 passed, 2 skipped)
- [x] 새 테스트 추가: `test_cli_no_stream_option`

## 관련 이슈

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)