### PR TITLE
feat: 참여자 목록 패널 및 에이전트 계층 구조 지원

### DIFF
--- a/config/agent_profiles.yaml
+++ b/config/agent_profiles.yaml
@@ -85,29 +85,29 @@ agents:
       # additional_instructions: |
       #   Always base your contributions on real data when tools are available.
       # review_required: true
-    # agents:
-    #   - name: Backend
-    #     role: backend_engineer
-    #     responsibilities:
-    #       - API 설계 및 구현
-    #       - 데이터베이스 최적화
-    #       - 서버 로직 개발
-    #     expertise:
-    #       - Python
-    #       - PostgreSQL
-    #       - FastAPI
-    #     phase_triggers: {}
-    #   - name: Frontend
-    #     role: frontend_engineer
-    #     responsibilities:
-    #       - UI 컴포넌트 구현
-    #       - 사용자 경험 최적화
-    #       - 반응형 디자인
-    #     expertise:
-    #       - React
-    #       - TypeScript
-    #       - CSS
-    #     phase_triggers: {}
+    agents:
+      - name: Backend
+        role: backend_engineer
+        responsibilities:
+          - API 설계 및 구현
+          - 데이터베이스 최적화
+          - 서버 로직 개발
+        expertise:
+          - Python
+          - PostgreSQL
+          - FastAPI
+        phase_triggers: {}
+      - name: Frontend
+        role: frontend_engineer
+        responsibilities:
+          - UI 컴포넌트 구현
+          - 사용자 경험 최적화
+          - 반응형 디자인
+        expertise:
+          - React
+          - TypeScript
+          - CSS
+        phase_triggers: {}
 
   # - name: DevOps
   #   role: devops_engineer
@@ -131,28 +131,7 @@ agents:
   #     - 사용성 테스트
   #   phase_triggers: {}
 
-  - name: Backend
-    role: backend_engineer
-    responsibilities:
-      - API 설계 및 구현
-      - 데이터베이스 최적화
-      - 서버 로직 개발
-    expertise:
-      - Python
-      - PostgreSQL
-      - FastAPI
-    phase_triggers: {}
-  - name: Frontend
-    role: frontend_engineer
-    responsibilities:
-      - UI 컴포넌트 구현
-      - 사용자 경험 최적화
-      - 반응형 디자인
-    expertise:
-      - React
-      - TypeScript
-      - CSS
-    phase_triggers: {}
+  # Backend/Frontend는 TechLead의 하위 에이전트로 동작
 
 
   # 사용자 참여 예시 (주석 해제 시 실제 사용자가 참여 가능)

--- a/config/agent_profiles_hierarchy_example.yaml
+++ b/config/agent_profiles_hierarchy_example.yaml
@@ -1,0 +1,44 @@
+agents:
+  - name: Host
+    role: host
+    responsibilities:
+      - 회의 진행 및 의사결정 정리
+    expertise:
+      - 퍼실리테이션
+      - 안건 관리
+    phase_triggers: {}
+
+  - name: PM
+    role: project_manager
+    responsibilities:
+      - 일정/리스크 관리
+    expertise:
+      - 프로젝트 관리
+    phase_triggers: {}
+
+  - name: TechLead
+    role: tech_lead
+    responsibilities:
+      - 기술 의사결정
+      - 아키텍처 리뷰
+    expertise:
+      - 시스템 설계
+      - 코드 품질
+    phase_triggers: {}
+    agents:
+      - name: Backend
+        role: backend_engineer
+        responsibilities:
+          - API 설계 및 서버 구현
+        expertise:
+          - Python
+          - FastAPI
+        phase_triggers: {}
+      - name: Frontend
+        role: frontend_engineer
+        responsibilities:
+          - UI 구현 및 개선
+        expertise:
+          - React
+          - TypeScript
+        phase_triggers: {}

--- a/tests/core/test_profile.py
+++ b/tests/core/test_profile.py
@@ -1,5 +1,11 @@
 import pytest
-from thetable.core.profile import AgentLLMConfig, AgentProfile, load_agent_profiles
+from thetable.core.profile import (
+    AgentLLMConfig,
+    AgentProfile,
+    flatten_all_profiles,
+    load_agent_profiles,
+    validate_no_cycles,
+)
 
 
 def test_agent_profile_creation():
@@ -65,13 +71,11 @@ def test_load_agent_profiles_from_yaml():
 
 def test_hierarchical_agent_profile():
     """계층적 Agent Profile 테스트"""
-    # 현재 TechLead는 하위 에이전트가 주석 처리되어 leaf 노드
     profiles = load_agent_profiles("config/agent_profiles.yaml")
     tech_lead = profiles["TechLead"]
 
-    # TechLead는 현재 leaf 노드 (agents 주석 처리됨)
-    assert not tech_lead.is_supervisor()
-    assert tech_lead.get_child_names() == []
+    assert tech_lead.is_supervisor()
+    assert tech_lead.get_child_names() == ["Backend", "Frontend"]
 
     # PM도 leaf 노드
     pm = profiles["PM"]
@@ -112,6 +116,45 @@ def test_host_profile_exists():
     # Host는 leaf 노드여야 함 (하위 에이전트 없음)
     assert not profiles["Host"].is_supervisor()
     assert profiles["Host"].get_child_names() == []
+
+
+def test_flatten_all_profiles_includes_nested_agents():
+    profiles = load_agent_profiles("config/agent_profiles.yaml")
+    flat_profiles = flatten_all_profiles(profiles)
+
+    assert {"Host", "PM", "TechLead", "Backend", "Frontend"}.issubset(flat_profiles.keys())
+    assert flat_profiles["Backend"].role == "backend_engineer"
+    assert flat_profiles["Frontend"].role == "frontend_engineer"
+
+
+def test_validate_no_cycles_raises_on_recursive_reference():
+    profiles = {
+        "A": AgentProfile(
+            name="A",
+            role="lead",
+            responsibilities=["coordination"],
+            expertise=["planning"],
+            agents=[
+                AgentProfile(
+                    name="B",
+                    role="worker",
+                    responsibilities=["execute"],
+                    expertise=["python"],
+                    agents=[
+                        AgentProfile(
+                            name="A",
+                            role="lead",
+                            responsibilities=["coordination"],
+                            expertise=["planning"],
+                        )
+                    ],
+                )
+            ],
+        )
+    }
+
+    with pytest.raises(ValueError, match="Agent cycle detected"):
+        validate_no_cycles(profiles)
 
 
 def test_host_profile_responsibilities():

--- a/tests/graph/nodes/test_agent_tool_binding.py
+++ b/tests/graph/nodes/test_agent_tool_binding.py
@@ -33,6 +33,7 @@ def _create_state(pending_proposals: list[dict[str, str]]) -> MeetingState:
         "pending_proposals": pending_proposals,
         "pending_speakers": [],
         "speaker_counts": {},
+        "participant_statuses": {},
         "consecutive_host_delegations": 0,
         "turn_count": 0,
         "max_turns": 1000,
@@ -84,3 +85,40 @@ async def test_host_with_pending_gets_propose_approve_reject_tools():
     tool_names = _tool_names_from_call(invoke_with_tools_mock)
     assert set(tool_names) == {"propose_agenda", "approve_agenda", "reject_agenda"}
     assert len(tool_names) == 3
+
+
+@pytest.mark.asyncio
+async def test_supervisor_agent_gets_sub_agent_tools():
+    profile = AgentProfile(
+        name="TechLead",
+        role="tech_lead",
+        responsibilities=["리드"],
+        expertise=["설계"],
+        agents=[
+            AgentProfile(
+                name="Backend",
+                role="backend_engineer",
+                responsibilities=["API 구현"],
+                expertise=["Python"],
+            ),
+            AgentProfile(
+                name="Frontend",
+                role="frontend_engineer",
+                responsibilities=["UI 구현"],
+                expertise=["React"],
+            ),
+        ],
+    )
+    node = AgentNode(profile=profile, model=MagicMock())
+    invoke_with_tools_mock: AsyncMock = AsyncMock(
+        return_value=AIMessage(content="테스트 응답", name="TechLead")
+    )
+    node.agent.invoke_with_tools = invoke_with_tools_mock
+
+    result = await node.execute(_create_state([]))
+
+    tool_names = _tool_names_from_call(invoke_with_tools_mock)
+    assert "propose_agenda" in tool_names
+    assert "ask_backend" in tool_names
+    assert "ask_frontend" in tool_names
+    assert cast(dict[str, str], result["participant_statuses"])["TechLead"] == "idle"

--- a/tests/graph/test_sub_agent_tool.py
+++ b/tests/graph/test_sub_agent_tool.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+from thetable.core.profile import AgentProfile
+from thetable.graph.sub_agent_tool import create_sub_agent_tool
+
+
+def test_create_sub_agent_tool_name_and_description():
+    sub_profile = AgentProfile(
+        name="Backend",
+        role="backend_engineer",
+        responsibilities=["API 설계", "DB 최적화"],
+        expertise=["Python", "PostgreSQL"],
+    )
+
+    tool = create_sub_agent_tool(
+        sub_profile=sub_profile,
+        model=MagicMock(),
+        parent_name="TechLead",
+        mcp_tools={},
+    )
+
+    assert tool.name == "ask_backend"
+    assert "상위 에이전트: TechLead" in tool.description
+    assert "책임: API 설계, DB 최적화" in tool.description
+    assert "전문분야: Python, PostgreSQL" in tool.description

--- a/thetable/core/profile.py
+++ b/thetable/core/profile.py
@@ -2,6 +2,7 @@
 from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 import yaml
+from loguru import logger
 
 
 class AgentLLMConfig(BaseModel):
@@ -46,14 +47,57 @@ class AgentProfile(BaseModel):
 AgentProfile.model_rebuild()
 
 
+def validate_no_cycles(profiles: Dict[str, AgentProfile]) -> None:
+    """하위 에이전트 순환 참조 검증."""
+
+    def dfs(profile: AgentProfile, path: List[str]) -> None:
+        if profile.name in path:
+            cycle_path = " -> ".join(path + [profile.name])
+            raise ValueError(f"Agent cycle detected: {cycle_path}")
+
+        next_path = path + [profile.name]
+        for child in profile.agents or []:
+            dfs(child, next_path)
+
+    for profile in profiles.values():
+        dfs(profile, [])
+
+
+def flatten_all_profiles(profiles: Dict[str, AgentProfile]) -> Dict[str, AgentProfile]:
+    """모든 레벨의 참여자를 flat dict로 반환."""
+    flat: Dict[str, AgentProfile] = {}
+
+    def walk(profile: AgentProfile) -> None:
+        if profile.name in flat:
+            raise ValueError(f"Duplicate agent name detected: {profile.name}")
+        flat[profile.name] = profile
+        for child in profile.agents or []:
+            walk(child)
+
+    for profile in profiles.values():
+        walk(profile)
+
+    return flat
+
+
 def load_agent_profiles(yaml_path: str) -> Dict[str, AgentProfile]:
     """YAML 파일에서 Agent Profile 로드"""
     with open(yaml_path, 'r', encoding='utf-8') as f:
         data = yaml.safe_load(f)
 
-    profiles = {}
+    profiles: Dict[str, AgentProfile] = {}
     for agent_data in data.get('agents', []):
-        profile = AgentProfile(**agent_data)
+        payload = dict(agent_data)
+        if payload.get("is_human") and payload.get("agents"):
+            logger.warning(
+                f"[{payload.get('name', 'unknown')}] is_human=true 이므로 agents 필드는 무시됩니다."
+            )
+            payload.pop("agents", None)
+
+        profile = AgentProfile(**payload)
+        if profile.name in profiles:
+            raise ValueError(f"Duplicate top-level agent name detected: {profile.name}")
         profiles[profile.name] = profile
 
+    validate_no_cycles(profiles)
     return profiles

--- a/thetable/graph/constants.py
+++ b/thetable/graph/constants.py
@@ -16,6 +16,22 @@ STATUS_TEXT = {
     "deferred": "보류"
 }
 
+# 참여자 상태 이모지
+PARTICIPANT_STATUS_EMOJI = {
+    "idle": "⚪",
+    "speaking": "🗣️",
+    "tool_calling": "🔧",
+    "waiting_input": "⌨️",
+}
+
+# 참여자 상태 텍스트
+PARTICIPANT_STATUS_TEXT = {
+    "idle": "대기 중",
+    "speaking": "발언 중",
+    "tool_calling": "도구 호출 중",
+    "waiting_input": "입력 대기",
+}
+
 # Host 역할 이름
 HOST_ROLE_NAME = "Host"
 

--- a/thetable/graph/nodes/agent.py
+++ b/thetable/graph/nodes/agent.py
@@ -8,13 +8,14 @@ from thetable.core.profile import AgentProfile
 from thetable.agents.base_agent import BaseAgent
 from thetable.graph.nodes.base import BaseNode, NodeType
 from thetable.graph.nodes.registry import register_node
-from thetable.graph.state import MeetingState
+from thetable.graph.state import MeetingState, ParticipantStatus
 from thetable.graph.constants import STATUS_EMOJI, STATUS_TEXT, HOST_ROLE_NAME
 from thetable.graph.agenda_tools import (
     create_propose_tool,
     create_approve_tool,
     create_reject_tool,
 )
+from thetable.graph.sub_agent_tool import create_sub_agent_tool
 
 
 @register_node("agent", category="agents")
@@ -61,6 +62,8 @@ class AgentNode(BaseNode):
         self.profile = profile
         self.all_agent_names = all_agent_names or []
         self.all_profiles = all_profiles or {}
+        self.sub_agent_tools: list = []
+        self._mcp_tools = mcp_tools or {}
 
         if model is None:
             from thetable.config import create_agent_llm, get_settings
@@ -72,11 +75,11 @@ class AgentNode(BaseNode):
             )
 
         # mcp_tools에서 agent_tools 자동 추출
-        if tools is None and mcp_tools and profile.mcp_tools:
+        if tools is None and self._mcp_tools and profile.mcp_tools:
             tools = []
             for server_name in profile.mcp_tools:
-                if server_name in mcp_tools:
-                    tools.extend(mcp_tools[server_name])
+                if server_name in self._mcp_tools:
+                    tools.extend(self._mcp_tools[server_name])
             if tools:
                 logger.info(
                     f"✅ {profile.name}: {len(tools)}개 MCP 도구 연결 "
@@ -90,6 +93,23 @@ class AgentNode(BaseNode):
         if tools:
             self.agent.bind_mcp_tools(tools)
             logger.info(f"[{profile.name}] 🔧 MCP 도구 바인딩: {len(tools)}개")
+
+        # supervisor profile이면 하위 에이전트를 tool로 바인딩
+        if profile.is_supervisor():
+            for sub_profile in profile.agents or []:
+                sub_tool = create_sub_agent_tool(
+                    sub_profile=sub_profile,
+                    model=model,
+                    parent_name=profile.name,
+                    mcp_tools=self._mcp_tools,
+                )
+                self.sub_agent_tools.append(sub_tool)
+            if self.sub_agent_tools:
+                logger.info(
+                    f"[{profile.name}] 👥 하위 에이전트 도구 바인딩: "
+                    f"{len(self.sub_agent_tools)}개"
+                )
+
     async def execute(self, state: MeetingState) -> Dict[str, Any]:
         """에이전트 발언 생성
 
@@ -104,6 +124,7 @@ class AgentNode(BaseNode):
         current_idx = state.get("current_agenda_idx", 0)
         summary = state.get("summary", "")
         pending_proposals: List[dict] = list(state.get("pending_proposals", []))
+        participant_statuses: Dict[str, str] = dict(state.get("participant_statuses", {}))
 
         # 대화 기록을 명확한 포맷으로 변환
         formatted_messages = []
@@ -163,13 +184,18 @@ class AgentNode(BaseNode):
             agenda_tools.append(create_approve_tool(agenda_actions, pending_proposals))
             agenda_tools.append(create_reject_tool(agenda_actions, pending_proposals))
 
+        all_tools = agenda_tools + self.sub_agent_tools
+
         # BaseAgent의 invoke_with_tools 사용
         config = {
             "tags": ["participant", f"speaker:{self.profile.name}"],
             "run_name": self.profile.name,
         }
+        participant_statuses[self.profile.name] = ParticipantStatus.speaking.value
+        if all_tools or getattr(self.agent, "_mcp_tools", []):
+            participant_statuses[self.profile.name] = ParticipantStatus.tool_calling.value
         response = await self.agent.invoke_with_tools(
-            all_messages, config=config, extra_tools=agenda_tools
+            all_messages, config=config, extra_tools=all_tools
         )
         response.name = self.profile.name
 
@@ -181,7 +207,11 @@ class AgentNode(BaseNode):
                 name=self.profile.name,
             )
 
-        result: Dict[str, Any] = {"messages": [response]}
+        participant_statuses[self.profile.name] = ParticipantStatus.idle.value
+        result: Dict[str, Any] = {
+            "messages": [response],
+            "participant_statuses": participant_statuses,
+        }
 
         # 안건 액션 처리
         if agenda_actions:

--- a/thetable/graph/state.py
+++ b/thetable/graph/state.py
@@ -1,4 +1,5 @@
 """Meeting state definition"""
+from enum import Enum
 from typing import List, Optional, Dict, Any
 from langgraph.graph import MessagesState
 from pydantic import BaseModel
@@ -26,6 +27,15 @@ class Agenda(BaseModel):
     end_time: Optional[float] = None  # Unix timestamp
 
 
+class ParticipantStatus(str, Enum):
+    """참여자 현재 상태"""
+
+    idle = "idle"
+    speaking = "speaking"
+    tool_calling = "tool_calling"
+    waiting_input = "waiting_input"
+
+
 class MeetingState(MessagesState):
     """회의 상태"""
 
@@ -39,6 +49,7 @@ class MeetingState(MessagesState):
 
     # 발언 추적
     speaker_counts: Dict[str, int] = {}
+    participant_statuses: Dict[str, str] = {}
 
     # Host 위임 추적 (무한루프 방지)
     consecutive_host_delegations: int = 0

--- a/thetable/graph/sub_agent_tool.py
+++ b/thetable/graph/sub_agent_tool.py
@@ -1,0 +1,82 @@
+"""Sub-agent tool factory."""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.tools import StructuredTool
+from pydantic import BaseModel, Field
+
+from thetable.agents.base_agent import BaseAgent
+from thetable.core.profile import AgentProfile
+
+
+class SubAgentInput(BaseModel):
+    """하위 에이전트 Tool 입력 스키마."""
+
+    question: str = Field(description="하위 에이전트에게 전달할 질문/요청")
+
+
+def _normalize_tool_name(name: str) -> str:
+    normalized = re.sub(r"[^a-z0-9_]+", "_", name.lower())
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    return normalized or "sub_agent"
+
+
+def _build_tool_description(sub_profile: AgentProfile, parent_name: str) -> str:
+    responsibilities = ", ".join(sub_profile.responsibilities[:3]) or "역할 기반 지원"
+    expertise = ", ".join(sub_profile.expertise[:3]) or "일반"
+    return (
+        f"{sub_profile.name}({sub_profile.role})에게 의견을 요청합니다. "
+        f"상위 에이전트: {parent_name}. "
+        f"책임: {responsibilities}. "
+        f"전문분야: {expertise}."
+    )
+
+
+def create_sub_agent_tool(
+    sub_profile: AgentProfile,
+    model,
+    parent_name: str,
+    mcp_tools: Optional[dict[str, list]] = None,
+) -> StructuredTool:
+    """하위 에이전트를 Tool로 래핑하여 반환."""
+    sub_agent = BaseAgent(name=sub_profile.name, profile=sub_profile, llm=model)
+
+    available_mcp_tools: list = []
+    if mcp_tools and sub_profile.mcp_tools:
+        for server_name in sub_profile.mcp_tools:
+            available_mcp_tools.extend(mcp_tools.get(server_name, []))
+    if available_mcp_tools:
+        sub_agent.bind_mcp_tools(available_mcp_tools)
+
+    async def ask_sub_agent(question: str) -> str:
+        messages = [
+            SystemMessage(
+                content=(
+                    f"당신은 {sub_profile.name}({sub_profile.role})입니다. "
+                    f"상위 에이전트 {parent_name}의 위임을 받아 답변합니다. "
+                    "핵심만 간결하게 한국어로 답하세요."
+                )
+            ),
+            HumanMessage(content=question),
+        ]
+        response = await sub_agent.invoke_with_tools(
+            messages,
+            config={
+                "tags": ["participant", f"speaker:{sub_profile.name}", f"delegated_by:{parent_name}"],
+                "run_name": sub_profile.name,
+            },
+        )
+        content = getattr(response, "content", "") or ""
+        return content.strip() or f"{sub_profile.name}의 응답이 비어 있습니다."
+
+    tool_name = f"ask_{_normalize_tool_name(sub_profile.name)}"
+    return StructuredTool.from_function(
+        coroutine=ask_sub_agent,
+        name=tool_name,
+        description=_build_tool_description(sub_profile, parent_name),
+        args_schema=SubAgentInput,
+    )

--- a/thetable/graph/workflow.py
+++ b/thetable/graph/workflow.py
@@ -168,6 +168,7 @@ def build_initial_state(
         "pending_proposals": [],
         "pending_speakers": [],
         "speaker_counts": {},
+        "participant_statuses": {},
         "consecutive_host_delegations": 0,
         "turn_count": 0,
         "max_turns": settings.max_turns,

--- a/thetable/interfaces/tui.py
+++ b/thetable/interfaces/tui.py
@@ -12,14 +12,21 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.message import Message
 from textual.reactive import reactive
-from textual.widgets import Footer, Header, Input, Static
+from textual.widgets import Footer, Header, Input, Static, Tree
 from textual.worker import WorkerCancelled
 from thetable.config import Settings
-from thetable.graph.constants import AGENT_COLORS, STATUS_EMOJI
+from thetable.graph.constants import (
+    AGENT_COLORS,
+    PARTICIPANT_STATUS_EMOJI,
+    PARTICIPANT_STATUS_TEXT,
+    STATUS_EMOJI,
+)
 from thetable.interfaces.time_utils import format_elapsed
 
 if TYPE_CHECKING:
+    from thetable.core.profile import AgentProfile
     from thetable.graph.input_provider import TuiInputProvider
+    from textual.widgets._tree import TreeNode
     from textual.timer import Timer
 
 
@@ -66,6 +73,13 @@ class ToolCallEnded(Message):
     def __init__(self, tool_name: str) -> None:
         super().__init__()
         self.tool_name = tool_name
+
+
+class ParticipantStatusChanged(Message):
+    def __init__(self, participant_name: str, status: str) -> None:
+        super().__init__()
+        self.participant_name = participant_name
+        self.status = status
 
 
 class MeetingEnded(Message):
@@ -137,6 +151,73 @@ class AgendaPanel(Static):
         self.update("\n".join(lines))
 
 
+class ParticipantPanel(Vertical):
+    """참여자 계층 및 상태 패널."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._top_profiles: dict[str, AgentProfile] = {}
+        self._flat_profiles: dict[str, AgentProfile] = {}
+        self._statuses: dict[str, str] = {}
+        self._participant_nodes: dict[str, TreeNode[Any]] = {}
+
+    def compose(self) -> ComposeResult:
+        yield Static("[bold]👥 참여자[/bold]")
+        yield Tree("participants", id="participant-tree")
+
+    def on_mount(self) -> None:
+        tree = self.query_one("#participant-tree", Tree)
+        tree.show_root = False
+
+    def initialize(
+        self,
+        top_profiles: dict[str, AgentProfile],
+        flat_profiles: dict[str, AgentProfile],
+    ) -> None:
+        self._top_profiles = top_profiles
+        self._flat_profiles = flat_profiles
+        self._statuses = {name: "idle" for name in flat_profiles}
+        self._rebuild_tree()
+
+    def update_status(self, participant_name: str, status: str) -> None:
+        self._statuses[participant_name] = status
+        node = self._participant_nodes.get(participant_name)
+        profile = self._flat_profiles.get(participant_name)
+        if node is not None:
+            node.set_label(self._format_label(participant_name, profile))
+
+    def _rebuild_tree(self) -> None:
+        tree = self.query_one("#participant-tree", Tree)
+        tree.root.remove_children()
+        self._participant_nodes = {}
+        for profile in self._top_profiles.values():
+            self._add_profile_node(tree.root, profile, is_top_level=True)
+        tree.root.expand()
+
+    def _add_profile_node(
+        self,
+        parent_node: TreeNode[Any],
+        profile: AgentProfile,
+        is_top_level: bool,
+    ) -> None:
+        node = parent_node.add(
+            self._format_label(profile.name, profile),
+            expand=is_top_level,
+        )
+        if not is_top_level and profile.agents:
+            node.collapse()
+        self._participant_nodes[profile.name] = node
+        for child in profile.agents or []:
+            self._add_profile_node(node, child, is_top_level=False)
+
+    def _format_label(self, name: str, profile: AgentProfile | None) -> str:
+        status = self._statuses.get(name, "idle")
+        status_emoji = PARTICIPANT_STATUS_EMOJI.get(status, "⚪")
+        status_text = PARTICIPANT_STATUS_TEXT.get(status, status)
+        role = profile.role if profile else "participant"
+        return f"{status_emoji} {name} ({role}) [{status_text}]"
+
+
 class MeetingTuiApp(App[None]):
     DEFAULT_CSS = """
     Screen {
@@ -146,10 +227,20 @@ class MeetingTuiApp(App[None]):
         height: 1fr;
     }
     #agenda-panel {
-        width: 55;
+        width: 45;
         border-left: solid $primary;
         padding: 1 2;
         background: $surface-darken-1;
+    }
+    #participant-panel {
+        width: 40;
+        border-right: solid $primary;
+        padding: 1 1;
+        background: $surface-darken-2;
+    }
+    #participant-tree {
+        height: 1fr;
+        margin-top: 1;
     }
     #main-panel {
         width: 1fr;
@@ -215,10 +306,12 @@ class MeetingTuiApp(App[None]):
         self._full_text: str = ""
         self._meeting_start_time: float = 0.0
         self._timer_interval: Timer | None = None
+        self._participant_statuses: dict[str, str] = {}
 
     def compose(self) -> ComposeResult:
         yield Header()
         with Horizontal():
+            yield ParticipantPanel(id="participant-panel")
             with Vertical(id="main-panel"):
                 with VerticalScroll(id="conversation-scroll"):
                     yield Static(id="conversation")
@@ -230,7 +323,7 @@ class MeetingTuiApp(App[None]):
 
     async def on_mount(self) -> None:
         from thetable.core.agenda import load_agendas
-        from thetable.core.profile import load_agent_profiles
+        from thetable.core.profile import flatten_all_profiles, load_agent_profiles
         from thetable.graph.input_provider import TuiInputProvider
         from thetable.graph.workflow import build_initial_state, create_meeting_workflow
 
@@ -242,12 +335,17 @@ class MeetingTuiApp(App[None]):
         )
 
         profiles = load_agent_profiles(self._profiles_path)
-        self._human_names = [name.lower() for name, p in profiles.items() if p.is_human]
+        all_profiles = flatten_all_profiles(profiles)
+        self._human_names = [name.lower() for name, p in all_profiles.items() if p.is_human]
+        participant_panel = self.query_one("#participant-panel", ParticipantPanel)
+        participant_panel.initialize(profiles, all_profiles)
+        self._participant_statuses = {name: "idle" for name in all_profiles}
 
         agendas = load_agendas(str(self._settings.agendas_path))
         self._initial_state = build_initial_state(
             self._settings, self._initial_message, self._human_names, agendas
         )
+        self._initial_state["participant_statuses"] = dict(self._participant_statuses)
         raw_start_time = self._initial_state.get("start_time")
         if isinstance(raw_start_time, (int, float)):
             self._meeting_start_time = float(raw_start_time)
@@ -359,6 +457,15 @@ class MeetingTuiApp(App[None]):
         pending = output_data.get("pending_speakers", [])
         self._last_agendas = output_data.get("agendas", self._last_agendas)
         self._last_speaker_counts = output_data.get("speaker_counts", self._last_speaker_counts)
+        raw_statuses = output_data.get("participant_statuses")
+        if isinstance(raw_statuses, dict):
+            for name, status in raw_statuses.items():
+                if (
+                    isinstance(name, str)
+                    and isinstance(status, str)
+                    and self._participant_statuses.get(name) != status
+                ):
+                    self.post_message(ParticipantStatusChanged(name, status))
         _ = pending
 
     def _handle_worker_tool_start(self, event: Any) -> None:
@@ -410,8 +517,12 @@ class MeetingTuiApp(App[None]):
         self._update_conversation()
 
     def on_speaker_changed(self, event: SpeakerChanged) -> None:
+        prev_speaker = self.current_speaker
         self.current_speaker = event.speaker
         self.input_enabled = False
+        if prev_speaker and prev_speaker != event.speaker:
+            self.post_message(ParticipantStatusChanged(prev_speaker, "idle"))
+        self.post_message(ParticipantStatusChanged(event.speaker, "speaking"))
         color_idx = hash(event.speaker) % len(AGENT_COLORS)
         color = AGENT_COLORS[color_idx]
         self._full_text += f"\n\n\n[bold {color}]── {event.speaker} ──[/bold {color}]\n\n"
@@ -427,20 +538,31 @@ class MeetingTuiApp(App[None]):
         label = self.query_one("#human-input-label", Static)
         agenda_title = self._get_current_agenda_title()
         label.update(escape(f"[{event.username}의 차례] {agenda_title}"))
+        self.post_message(ParticipantStatusChanged(event.username, "waiting_input"))
         self.input_enabled = True
         self._full_text += f"\n\n[bold yellow]── {event.username}님 차례입니다 ──[/bold yellow]\n"
         self._update_conversation()
 
     def on_turn_completed(self, event: TurnCompleted) -> None:
-        pass
+        if event.speaker:
+            self.post_message(ParticipantStatusChanged(event.speaker, "idle"))
 
     def on_tool_call_started(self, event: ToolCallStarted) -> None:
+        if self.current_speaker:
+            self.post_message(ParticipantStatusChanged(self.current_speaker, "tool_calling"))
         self._full_text += f"[dim]⚙ {event.tool_name} 호출 중...[/dim]"
         self._update_conversation()
 
     def on_tool_call_ended(self, event: ToolCallEnded) -> None:
+        if self.current_speaker:
+            self.post_message(ParticipantStatusChanged(self.current_speaker, "speaking"))
         self._full_text += " [dim]✓[/dim]\n"
         self._update_conversation()
+
+    def on_participant_status_changed(self, event: ParticipantStatusChanged) -> None:
+        self._participant_statuses[event.participant_name] = event.status
+        participant_panel = self.query_one("#participant-panel", ParticipantPanel)
+        participant_panel.update_status(event.participant_name, event.status)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         if self._input_provider is not None:


### PR DESCRIPTION
## Summary
- TUI에 `ParticipantPanel` 추가 — Textual Tree 위젯 기반 계층적 참여자 목록 및 실시간 상태 표시
- 하위 에이전트를 상위 에이전트의 Tool로 등록하여 위임 호출 지원 (그래프 토폴로지 변경 없음)
- `ParticipantStatus` enum, 순환 참조 탐지, 전체 프로필 flatten 등 기반 인프라 추가

## Changes
- **신규**: `thetable/graph/sub_agent_tool.py` — 하위 에이전트 Tool 팩토리 (MCP 도구 바인딩 포함)
- **수정**: `thetable/core/profile.py` — `validate_no_cycles()`, `flatten_all_profiles()`, is_human agents 무시
- **수정**: `thetable/graph/state.py` — `ParticipantStatus` enum, `participant_statuses` 필드
- **수정**: `thetable/graph/nodes/agent.py` — 하위 에이전트 Tool 생성/바인딩, 상태 추적
- **수정**: `thetable/interfaces/tui.py` — `ParticipantPanel`, `ParticipantStatusChanged` 이벤트
- **수정**: `config/agent_profiles.yaml` — TechLead 하위 Backend/Frontend 활성화
- **테스트**: 순환 참조, flatten, supervisor Tool 바인딩 테스트 추가

Closes #191

## Test plan
- [ ] 기존 flat YAML로 워크플로우 정상 동작 확인 (하위 호환성)
- [ ] 계층 YAML로 TUI 실행 시 참여자 트리 표시 확인
- [ ] TechLead 발언 중 ask_backend/ask_frontend Tool 호출 확인
- [ ] `uv run pytest tests/core/test_profile.py tests/graph/` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)