### PR TITLE
feat: 참여자 패널을 안건 패널 아래로 이동

### DIFF
--- a/thetable/interfaces/tui.py
+++ b/thetable/interfaces/tui.py
@@ -226,15 +226,19 @@ class MeetingTuiApp(App[None]):
     Horizontal {
         height: 1fr;
     }
-    #agenda-panel {
+    #right-sidebar {
         width: 45;
         border-left: solid $primary;
+    }
+    #agenda-panel {
+        height: 1fr;
         padding: 1 2;
         background: $surface-darken-1;
     }
     #participant-panel {
-        width: 40;
-        border-right: solid $primary;
+        height: auto;
+        max-height: 50%;
+        border-top: solid $primary;
         padding: 1 1;
         background: $surface-darken-2;
     }
@@ -311,11 +315,12 @@ class MeetingTuiApp(App[None]):
     def compose(self) -> ComposeResult:
         yield Header()
         with Horizontal():
-            yield ParticipantPanel(id="participant-panel")
             with Vertical(id="main-panel"):
                 with VerticalScroll(id="conversation-scroll"):
                     yield Static(id="conversation")
-            yield AgendaPanel(id="agenda-panel")
+            with Vertical(id="right-sidebar"):
+                yield AgendaPanel(id="agenda-panel")
+                yield ParticipantPanel(id="participant-panel")
         with Vertical(id="human-input-panel"):
             yield Static("의견을 입력하세요", id="human-input-label")
             yield Input(id="input-area", placeholder="의견을 입력하세요 (Enter로 전송, 빈 입력 시 스킵)")
@@ -588,8 +593,8 @@ class MeetingTuiApp(App[None]):
         self._update_conversation()
 
     def on_resize(self) -> None:
-        agenda_panel = self.query_one("#agenda-panel", AgendaPanel)
-        agenda_panel.display = self.size.width >= 100
+        sidebar = self.query_one("#right-sidebar", Vertical)
+        sidebar.display = self.size.width >= 100
 
     async def action_quit(self) -> None:
         self.workers.cancel_all()


### PR DESCRIPTION
## Summary

- 3-column 레이아웃(참여자|대화|안건) → 2-column 레이아웃(대화|[안건/참여자])으로 변경
- 안건+참여자 패널을 `#right-sidebar` Vertical 컨테이너로 통합
- 대화 영역 약 40칸 확장

## Changes

- `compose()`: 참여자·안건 패널을 `#right-sidebar` Vertical 아래로 통합
- `DEFAULT_CSS`: `#right-sidebar` 스타일 추가, 각 패널에서 `width`/`border` 재조정
- `on_resize()`: 안건 패널 개별 숨김 → 사이드바 전체 숨김으로 변경

## Test plan

- [x] `uv run pytest tests/interfaces/test_tui.py tests/interfaces/test_tui_timer.py` → 9 passed

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)