### PR TITLE
fix: show human TUI input in conversation panel

### DIFF
--- a/tests/interfaces/test_tui.py
+++ b/tests/interfaces/test_tui.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import pytest
-from textual.widgets import Input, Static
+from textual.widgets import Input, Markdown, Static
 
 from thetable.config import Settings
-from thetable.interfaces.tui import HumanTurnStarted, MeetingTuiApp, SpeakerChanged
+from thetable.interfaces.tui import HumanTurnStarted, MeetingTuiApp, SpeakerChanged, SpeechBubble
 
 
 class DummyMeetingTuiApp(MeetingTuiApp):
@@ -15,9 +15,24 @@ class DummyMeetingTuiApp(MeetingTuiApp):
     async def on_mount(self) -> None:
         return
 
+    def run_meeting_worker(self) -> None:
+        return
+
+
+class RecordingInputProvider:
+    def __init__(self) -> None:
+        self.submitted: list[str] = []
+
+    def submit_input(self, value: str) -> None:
+        self.submitted.append(value)
+
 
 def _static_text(widget: Static) -> str:
     return str(widget.content)
+
+
+def _speaker_bubbles(app: MeetingTuiApp, speaker: str) -> list[SpeechBubble]:
+    return [bubble for bubble in app.query(SpeechBubble) if bubble._speaker == speaker]
 
 
 @pytest.mark.asyncio
@@ -95,3 +110,56 @@ async def test_get_current_agenda_title_fallbacks() -> None:
 
         app.current_agenda_idx = 0
         assert app._get_current_agenda_title() == "로드맵"
+
+
+@pytest.mark.asyncio
+async def test_input_submission_mounts_human_bubble_and_forwards_value() -> None:
+    app = DummyMeetingTuiApp(
+        settings=Settings(),
+        profiles_path="config/agent_profiles.yaml",
+        initial_message="hello",
+    )
+
+    async with app.run_test() as pilot:
+        input_provider = RecordingInputProvider()
+        app._input_provider = input_provider
+        app.on_human_turn_started(HumanTurnStarted(username="민지"))
+        await pilot.pause()
+
+        input_widget = app.query_one("#input-area", Input)
+        app.on_input_submitted(Input.Submitted(input=input_widget, value="찬성합니다"))
+        await pilot.pause()
+
+        bubbles = _speaker_bubbles(app, "민지")
+        panel = app.query_one("#human-input-panel")
+
+        assert input_provider.submitted == ["찬성합니다"]
+        assert len(bubbles) == 1
+        assert bubbles[0]._buffer == "찬성합니다"
+        assert bubbles[0]._body is None
+        assert bubbles[0].query_one(Markdown)
+        assert "visible" not in panel.classes
+        assert app._current_human_speaker == ""
+
+
+@pytest.mark.asyncio
+async def test_blank_input_submission_skips_human_bubble() -> None:
+    app = DummyMeetingTuiApp(
+        settings=Settings(),
+        profiles_path="config/agent_profiles.yaml",
+        initial_message="hello",
+    )
+
+    async with app.run_test() as pilot:
+        input_provider = RecordingInputProvider()
+        app._input_provider = input_provider
+        app.on_human_turn_started(HumanTurnStarted(username="민지"))
+        await pilot.pause()
+
+        input_widget = app.query_one("#input-area", Input)
+        app.on_input_submitted(Input.Submitted(input=input_widget, value="   "))
+        await pilot.pause()
+
+        assert input_provider.submitted == ["   "]
+        assert _speaker_bubbles(app, "민지") == []
+        assert app._current_human_speaker == ""

--- a/thetable/interfaces/tui.py
+++ b/thetable/interfaces/tui.py
@@ -474,6 +474,7 @@ class MeetingTuiApp(App[None]):
         self._current_bubble: SpeechBubble | None = None
         self._current_delegated_bubble: SpeechBubble | None = None
         self._current_delegated_speaker: str = ""
+        self._current_human_speaker: str = ""
         self._speaker_colors: dict[str, str] = {}
         self._meeting_start_time: float = 0.0
         self._timer_interval: Timer | None = None
@@ -760,6 +761,7 @@ class MeetingTuiApp(App[None]):
 
         self._current_delegated_bubble = None
         self._current_delegated_speaker = ""
+        self._current_human_speaker = ""
         prev_speaker = self.current_speaker
         self.current_speaker = event.speaker
         self.input_enabled = False
@@ -783,6 +785,7 @@ class MeetingTuiApp(App[None]):
     def on_human_turn_started(self, event: HumanTurnStarted) -> None:
         label = self.query_one("#human-input-label", Static)
         agenda_title = self._get_current_agenda_title()
+        self._current_human_speaker = event.username
         label.update(escape(f"[{event.username}의 차례] {agenda_title}"))
         self.post_message(ParticipantStatusChanged(event.username, "waiting_input"))
         self.input_enabled = True
@@ -827,10 +830,20 @@ class MeetingTuiApp(App[None]):
         participant_panel.update_status(event.participant_name, event.status)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
+        submitted_value = event.value
         if self._input_provider is not None:
-            self._input_provider.submit_input(event.value)
+            self._input_provider.submit_input(submitted_value)
+        if submitted_value.strip() and self._current_human_speaker:
+            bubble = SpeechBubble(
+                speaker=self._current_human_speaker,
+                color=self._get_speaker_color(self._current_human_speaker),
+            )
+            bubble.append_token(submitted_value)
+            self._mount_bubble(bubble)
+            self.call_after_refresh(bubble.finalize)
         event.input.clear()
         self.input_enabled = False
+        self._current_human_speaker = ""
 
     def on_meeting_ended(self, event: MeetingEnded) -> None:
         self._last_agendas = event.agendas


### PR DESCRIPTION
## Summary
- show submitted human input in the TUI conversation panel immediately after Enter
- keep blank input behavior as skip while still forwarding submitted values to the input provider
- add TUI regression tests for visible human bubbles and blank-input skip behavior

## Testing
- uv run pytest tests/interfaces/test_tui.py

Closes #199