### PR TITLE
fix: enforce explicit mention routing (#214)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,8 @@ LLM_TASK_MODEL=google/gemini-2.5-flash
 # LLM_TASK_MODEL=gpt-5-nano
 
 LLM_TASK_TEMPERATURE=0.0
-LLM_TASK_MAX_TOKENS=2048
+LLM_TASK_MAX_TOKENS=256
+MENTION_EXTRACTION_MAX_TOKENS=64  # Human 입력 fallback 멘션 추출 상한
 
 # Task LLM 전용 제공자 사용 시 (선택적)
 # 예시 1: Azure OpenAI
@@ -67,7 +68,7 @@ RECURSION_LIMIT=1000  # LangGraph 재귀 깊이 제한 (기본값: 1000)
 MAX_TURNS=1000  # 회의 최대 턴 수 (무한루프 방지, 기본값: 1000)
 
 # 대화 요약 설정
-MAX_MESSAGES_BEFORE_SUMMARY=5  # 이 개수 초과 시 요약 생성 (기본값: 5)
+MAX_MESSAGES_BEFORE_SUMMARY=8  # 이 개수 초과 시 요약 생성 (기본값: 8)
 KEEP_RECENT_MESSAGES=3  # 요약 후 유지할 최근 메시지 개수 (기본값: 3)
 SUMMARY_MAX_TOKENS=3000  # 요약 최대 토큰 수 (기본값: 3000)
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ agendas:
 | `LLM_TASK_MODEL` | Utility task model | `gpt-4o-mini` |
 | `LLM_MAIN_TEMPERATURE` | Main LLM temperature | `0.7` |
 | `LLM_TASK_TEMPERATURE` | Task LLM temperature | `0.0` |
+| `LLM_TASK_MAX_TOKENS` | Utility task token cap | `256` |
+| `MENTION_EXTRACTION_MAX_TOKENS` | Human mention fallback token cap | `64` |
 | `MAX_TURNS` | Max meeting turns | `1000` |
 | `AGENT_PROFILES_PATH` | Path to profiles YAML | `config/agent_profiles.yaml` |
 
@@ -187,6 +189,8 @@ User ──► CLI/TUI ──► LangGraph StateGraph
 - **ProcessResponseNode** — Extracts mentions, detects agenda completion, manages speaker queue
 - **RefillSpeakersNode** — Ensures required speakers participate in each agenda item
 - **SummarizationNode** — Compresses conversation history to stay within context limits
+
+AI participants must call other participants with `@Name` prefixes such as `@PM` or `@TechLead`. The routing layer treats AI responses without `@Name` as non-routing text and only keeps natural-language fallback for human input during the migration period.
 
 ## WebSocket Server
 

--- a/doorae/config/settings.py
+++ b/doorae/config/settings.py
@@ -29,7 +29,8 @@ class Settings(BaseSettings):
     llm_task_base_url: Optional[str] = None  # Task LLM 전용 (None이면 openai_base_url 사용)
     llm_task_model: str = "gpt-4o-mini"  # 나중에 gpt-3.5-turbo 등으로 변경 가능
     llm_task_temperature: float = 0.0    # 일관된 결과 위해 낮게
-    llm_task_max_tokens: int = 2048  # Task LLM은 더 짧은 응답
+    llm_task_max_tokens: int = 256  # Task LLM은 짧은 응답 위주
+    mention_extraction_max_tokens: int = 64  # Human fallback 멘션 추출 상한
 
     # LLM 연결 설정
     llm_timeout: float = 60.0  # 초 단위
@@ -47,7 +48,7 @@ class Settings(BaseSettings):
     tui_enabled: bool = True  # --no-tui 플래그로 비활성화 가능
 
     # 대화 요약 설정
-    max_messages_before_summary: int = 5  # 이 개수 초과 시 요약
+    max_messages_before_summary: int = 8  # 이 개수 초과 시 요약
     keep_recent_messages: int = 3  # 최근 몇 개 유지
     summary_max_tokens: int = 3000  # 요약 최대 토큰
 

--- a/doorae/graph/nodes/agent.py
+++ b/doorae/graph/nodes/agent.py
@@ -250,9 +250,11 @@ class AgentNode(BaseNode):
 다른 참여자: {', '.join(formatted_participants)}
 (* 표시는 실제 사용자입니다)
 
-다른 참여자의 의견이 필요하면 자연스럽게 언급하세요.
-예: "Designer님의 의견도 듣고 싶습니다"
-"""
+다른 참여자의 응답이 필요하면 반드시 @이름 형식으로 호출하세요.
+예: "@PM 의견 부탁드립니다"
+여러 명을 호출할 때는 "@PM @TechLead 검토 부탁드립니다"처럼 작성하세요.
+조사나 존칭은 붙여도 되지만, 반드시 @이름 prefix를 포함해야 합니다.
+                """
 
         # metadata 섹션 생성
         metadata_section = ""

--- a/doorae/graph/nodes/process.py
+++ b/doorae/graph/nodes/process.py
@@ -1,9 +1,12 @@
 """ProcessResponseNode - 에이전트 응답 처리"""
 
+import re
 import time
 from typing import Dict, Any
+from langchain_core.messages import AIMessage, HumanMessage
 from loguru import logger
 
+from doorae.config import get_settings
 from doorae.graph.nodes.base import BaseNode, NodeType
 from doorae.graph.nodes.registry import register_node
 from doorae.graph.state import MeetingState
@@ -38,15 +41,63 @@ class ProcessResponseNode(BaseNode):
         self.model = model
         self.valid_speakers = valid_speakers
 
-    async def _extract_mentions(self, content: str) -> list[str]:
-        """LLM 기반 멘션 추출
+    def _extract_at_mentions(self, content: str) -> list[str]:
+        """`@Name` prefix 기반 멘션 추출."""
+        if not content or not self.valid_speakers:
+            return []
 
-        Args:
-            content: 발언 내용
+        ordered_speakers = sorted(self.valid_speakers, key=len, reverse=True)
+        pattern = re.compile(
+            r"@(" + "|".join(re.escape(speaker) for speaker in ordered_speakers) + r")"
+        )
 
-        Returns:
-            언급된 참여자 이름 리스트
-        """
+        mentions: list[str] = []
+        for match in pattern.finditer(content):
+            speaker = match.group(1)
+            if speaker not in mentions:
+                mentions.append(speaker)
+        return mentions
+
+    def _extract_natural_name_mentions(self, content: str) -> list[str]:
+        """HumanMessage 호환용 자연어 이름 멘션 추출."""
+        if not content or not self.valid_speakers:
+            return []
+
+        ordered_speakers = sorted(self.valid_speakers, key=len, reverse=True)
+        pattern = re.compile(
+            "|".join(re.escape(speaker) for speaker in ordered_speakers)
+        )
+
+        mentions: list[str] = []
+        for match in pattern.finditer(content):
+            speaker = match.group(0)
+            if speaker not in mentions:
+                mentions.append(speaker)
+        return mentions
+
+    def _looks_like_delegation_without_mentions(self, content: str) -> bool:
+        """AI 응답이 멘션 없이 위임/호명을 시도하는지 추정."""
+        if not content:
+            return False
+
+        request_cues = [
+            "의견",
+            "검토",
+            "부탁",
+            "생각",
+            "말씀",
+            "답변",
+            "확인",
+            "주시겠",
+            "해주세요",
+        ]
+        if any(speaker in content for speaker in self.valid_speakers):
+            return True
+        return any(cue in content for cue in request_cues)
+
+    async def _extract_mentions_with_llm(self, content: str) -> list[str]:
+        """HumanMessage fallback용 제한된 LLM 멘션 추출."""
+        settings = get_settings()
         prompt = f"""다음 발언에서 언급하거나 의견을 요청하는 참여자를 추출하세요.
 
 발언: "{content}"
@@ -56,7 +107,8 @@ class ProcessResponseNode(BaseNode):
 언급된 참여자 이름만 쉼표로 구분하여 출력 (없으면 "없음"):"""
 
         try:
-            response = await self.model.ainvoke(prompt)
+            response_model = self.model.bind(max_tokens=settings.mention_extraction_max_tokens)
+            response = await response_model.ainvoke(prompt)
             result = response.content.strip()
 
             if result == "없음":
@@ -64,8 +116,34 @@ class ProcessResponseNode(BaseNode):
 
             return [s.strip() for s in result.split(",") if s.strip() in self.valid_speakers]
         except Exception as e:
-            logger.warning(f"⚠️ 멘션 추출 LLM 호출 실패 (발언: {content[:30]}...): {type(e).__name__}: {e}")
+            logger.warning(
+                f"⚠️ 멘션 추출 LLM 호출 실패 (발언: {content[:30]}...): {type(e).__name__}: {e}"
+            )
             return []
+
+    async def _extract_mentions(self, message: Any) -> list[str]:
+        """메시지 유형별 멘션 추출."""
+        content = getattr(message, "content", "") or ""
+        at_mentions = self._extract_at_mentions(content)
+        if at_mentions:
+            return at_mentions
+
+        if isinstance(message, AIMessage):
+            if self._looks_like_delegation_without_mentions(content):
+                logger.warning(
+                    "⚠️ AI response attempted delegation without @mention "
+                    f"(speaker={getattr(message, 'name', '')}, content={content[:80]!r})"
+                )
+            return []
+
+        natural_mentions = self._extract_natural_name_mentions(content)
+        if natural_mentions:
+            return natural_mentions
+
+        if isinstance(message, HumanMessage) and self._looks_like_delegation_without_mentions(content):
+            return await self._extract_mentions_with_llm(content)
+
+        return []
 
     def _detect_agenda_completion(self, content: str) -> bool:
         """Host 발언에서 안건 완료 키워드 감지
@@ -124,7 +202,7 @@ class ProcessResponseNode(BaseNode):
 회의 종료 의도가 명확하면 "예", 아니면 "아니오"로만 답하세요:"""
 
         try:
-            response = await self.model.ainvoke(prompt)
+            response = await self.model.bind(max_tokens=16).ainvoke(prompt)
             result = response.content.strip()
 
             return result == "예"
@@ -162,7 +240,7 @@ class ProcessResponseNode(BaseNode):
         new_counts[speaker_name] = new_counts.get(speaker_name, 0) + 1
 
         # 3. 멘션 추출 (LLM 기반)
-        mentions = await self._extract_mentions(content)
+        mentions = await self._extract_mentions(last_msg)
 
         # 4. 새 멘션을 pending에 추가 (중복 제외)
         for m in mentions:

--- a/doorae/graph/nodes/summarize.py
+++ b/doorae/graph/nodes/summarize.py
@@ -90,6 +90,9 @@ class SummarizationNode(BaseNode):
             name = getattr(msg, "name", "Unknown")
             formatted_messages.append(HumanMessage(content=f"[{name}]: {content}"))
 
+        if len(formatted_messages) < 3:
+            return {}
+
         # 요약 프롬프트 추가
         formatted_messages.append(HumanMessage(content=summary_prompt))
 

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -45,6 +45,9 @@ class TestSettings:
         assert settings.llm_main_temperature == 0.7
         assert settings.llm_task_model == "gpt-4o-mini"
         assert settings.llm_task_temperature == 0.0
+        assert settings.llm_task_max_tokens == 256
+        assert settings.mention_extraction_max_tokens == 64
+        assert settings.max_messages_before_summary == 8
         assert settings.agent_profiles_path == "config/agent_profiles.yaml"
 
     def test_missing_api_key(self, monkeypatch):

--- a/tests/graph/nodes/test_agent_actions.py
+++ b/tests/graph/nodes/test_agent_actions.py
@@ -16,6 +16,33 @@ def _create_node() -> AgentNode:
     return AgentNode(profile=profile, model=MagicMock())
 
 
+def _create_prompt_node() -> AgentNode:
+    host = AgentProfile(
+        name="Host",
+        role="host",
+        responsibilities=["facilitate"],
+        expertise=["coordination"],
+    )
+    pm = AgentProfile(
+        name="PM",
+        role="pm",
+        responsibilities=["plan"],
+        expertise=["roadmap"],
+    )
+    techlead = AgentProfile(
+        name="TechLead",
+        role="tech_lead",
+        responsibilities=["review"],
+        expertise=["architecture"],
+    )
+    return AgentNode(
+        profile=host,
+        model=MagicMock(),
+        all_agent_names=["Host", "PM", "TechLead"],
+        all_profiles={"Host": host, "PM": pm, "TechLead": techlead},
+    )
+
+
 def _apply_actions(
     node: AgentNode,
     actions: Sequence[Mapping[str, object]],
@@ -156,3 +183,13 @@ def test_apply_agenda_actions_duplicate_approve_same_index_adds_once():
 
     assert result["agendas"] == [*agendas, proposal]  # 1번만 추가
     assert result["pending_proposals"] == []  # 제거는 정상
+
+
+def test_build_agent_prompt_requires_at_mentions():
+    node = _create_prompt_node()
+
+    prompt = node._build_agent_prompt()
+
+    assert "@PM" in prompt
+    assert "@TechLead" in prompt
+    assert "반드시 @이름 형식" in prompt

--- a/tests/graph/nodes/test_process.py
+++ b/tests/graph/nodes/test_process.py
@@ -2,6 +2,8 @@
 
 import inspect
 import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from unittest.mock import AsyncMock, MagicMock
 from doorae.graph.nodes.process import ProcessResponseNode, NodeType
 
 
@@ -53,10 +55,126 @@ class TestProcessResponseNode:
 
     def test_keyword_meeting_end_detection(self):
         """키워드 기반 회의 종료 감지가 여전히 동작하는지 확인"""
-        from unittest.mock import MagicMock
-
         node = ProcessResponseNode(model=MagicMock(), valid_speakers=["Host"])
 
         assert node._detect_meeting_end_keyword("회의를 마치겠습니다") is True
         assert node._detect_meeting_end_keyword("수고하셨습니다") is True
         assert node._detect_meeting_end_keyword("다음 안건으로 이동합니다") is False
+
+    @pytest.mark.asyncio
+    async def test_extract_mentions_from_ai_message_uses_at_prefix(self, monkeypatch):
+        warn = MagicMock()
+        monkeypatch.setattr("doorae.graph.nodes.process.logger.warning", warn)
+
+        model = MagicMock()
+        model.ainvoke = AsyncMock()
+        node = ProcessResponseNode(model=model, valid_speakers=["Host", "PM", "TechLead"])
+
+        mentions = await node._extract_mentions(
+            AIMessage(content="@PM님 의견 부탁드립니다. @TechLead에게도 검토 부탁드립니다.", name="Host")
+        )
+
+        assert mentions == ["PM", "TechLead"]
+        model.ainvoke.assert_not_called()
+        warn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_extract_mentions_from_ai_message_has_no_fallback(self, monkeypatch):
+        warn = MagicMock()
+        monkeypatch.setattr("doorae.graph.nodes.process.logger.warning", warn)
+
+        model = MagicMock()
+        model.ainvoke = AsyncMock()
+        node = ProcessResponseNode(model=model, valid_speakers=["Host", "PM", "TechLead"])
+
+        mentions = await node._extract_mentions(
+            AIMessage(content="PM님 의견 부탁드립니다.", name="Host")
+        )
+
+        assert mentions == []
+        model.ainvoke.assert_not_called()
+        warn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_extract_mentions_prefers_longer_names_first(self, monkeypatch):
+        warn = MagicMock()
+        monkeypatch.setattr("doorae.graph.nodes.process.logger.warning", warn)
+
+        model = MagicMock()
+        model.ainvoke = AsyncMock()
+        node = ProcessResponseNode(model=model, valid_speakers=["PM", "PMO"])
+
+        mentions = await node._extract_mentions(
+            AIMessage(content="@PMO님 확인 부탁드립니다.", name="Host")
+        )
+
+        assert mentions == ["PMO"]
+        model.ainvoke.assert_not_called()
+        warn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_extract_mentions_from_human_message_supports_natural_name_without_llm(self):
+        model = MagicMock()
+        model.ainvoke = AsyncMock()
+        node = ProcessResponseNode(model=model, valid_speakers=["Host", "PM", "TechLead"])
+
+        mentions = await node._extract_mentions(
+            HumanMessage(content="PM님 의견 부탁드립니다.", name="chulsoo")
+        )
+
+        assert mentions == ["PM"]
+        model.ainvoke.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_extract_mentions_from_human_message_uses_limited_llm_fallback(self, monkeypatch):
+        response_model = MagicMock()
+        response_model.ainvoke = AsyncMock(return_value=MagicMock(content="PM"))
+
+        model = MagicMock()
+        model.bind.return_value = response_model
+        node = ProcessResponseNode(model=model, valid_speakers=["Host", "PM", "TechLead"])
+
+        monkeypatch.setattr(
+            "doorae.graph.nodes.process.get_settings",
+            lambda: MagicMock(mention_extraction_max_tokens=64),
+        )
+
+        mentions = await node._extract_mentions(
+            HumanMessage(content="누가 답변하면 좋을까요? 의견 부탁드립니다.", name="chulsoo")
+        )
+
+        assert mentions == ["PM"]
+        model.bind.assert_called_once_with(max_tokens=64)
+        response_model.ainvoke.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_detect_meeting_end_llm_uses_small_token_cap(self):
+        response_model = MagicMock()
+        response_model.ainvoke = AsyncMock(return_value=MagicMock(content="예"))
+
+        model = MagicMock()
+        model.bind.return_value = response_model
+        node = ProcessResponseNode(model=model, valid_speakers=["Host"])
+
+        result = await node._detect_meeting_end_llm("회의를 마칠까요?")
+
+        assert result is True
+        model.bind.assert_called_once_with(max_tokens=16)
+        response_model.ainvoke.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_routes_ai_mentions_into_pending_queue(self):
+        node = ProcessResponseNode(model=MagicMock(), valid_speakers=["Host", "PM", "TechLead"])
+        state = {
+            "messages": [AIMessage(content="@PM님 의견 부탁드립니다.", name="Host")],
+            "agendas": [{"title": "Test", "status": "in_progress", "required_speakers": ["Host", "PM"]}],
+            "current_agenda_idx": 0,
+            "pending_speakers": ["Host"],
+            "speaker_counts": {},
+            "turn_count": 0,
+        }
+
+        result = await node.execute(state)
+
+        assert result["pending_speakers"] == ["PM"]
+        assert result["speaker_counts"] == {"Host": 1}

--- a/tests/graph/nodes/test_summarize.py
+++ b/tests/graph/nodes/test_summarize.py
@@ -1,7 +1,7 @@
 """SummarizationNode 테스트"""
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from doorae.graph.nodes.summarize import SummarizationNode, NodeType
 from doorae.graph.state import MeetingState
 
@@ -49,3 +49,75 @@ class TestSummarizationNode:
         result = await node.execute(state)
 
         assert result == {}  # 변경 없음
+
+    @pytest.mark.asyncio
+    async def test_no_summarization_when_too_few_non_empty_messages(self, monkeypatch):
+        """요약 대상 실질 메시지가 적으면 요약하지 않음"""
+        monkeypatch.setattr(
+            "doorae.graph.nodes.summarize.get_settings",
+            lambda: MagicMock(
+                max_messages_before_summary=3,
+                keep_recent_messages=3,
+                summary_max_tokens=3000,
+            ),
+        )
+
+        mock_model = MagicMock()
+        node = SummarizationNode(model=mock_model)
+
+        messages = []
+        raw_messages = [
+            ("msg_0", "Alice", "첫 번째"),
+            ("msg_1", "Alice", ""),
+            ("msg_2", "Alice", "   "),
+            ("msg_3", "Bob", "최근 1"),
+            ("msg_4", "Bob", "최근 2"),
+            ("msg_5", "Bob", "최근 3"),
+        ]
+        for msg_id, name, content in raw_messages:
+            msg = MagicMock()
+            msg.id = msg_id
+            msg.content = content
+            msg.name = name
+            messages.append(msg)
+
+        state = MeetingState(messages=messages, summary="")
+
+        result = await node.execute(state)
+
+        assert result == {}
+        mock_model.bind.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_summarization_binds_summary_max_tokens(self, monkeypatch):
+        """요약 시 summary_max_tokens로 바인딩"""
+        monkeypatch.setattr(
+            "doorae.graph.nodes.summarize.get_settings",
+            lambda: MagicMock(
+                max_messages_before_summary=3,
+                keep_recent_messages=1,
+                summary_max_tokens=1234,
+            ),
+        )
+
+        response_model = MagicMock()
+        response_model.ainvoke = AsyncMock(return_value=MagicMock(content="요약"))
+        mock_model = MagicMock()
+        mock_model.bind.return_value = response_model
+        node = SummarizationNode(model=mock_model)
+
+        messages = []
+        for i in range(5):
+            msg = MagicMock()
+            msg.id = f"msg_{i}"
+            msg.content = f"메시지 {i}"
+            msg.name = "Alice"
+            messages.append(msg)
+
+        state = MeetingState(messages=messages, summary="")
+
+        result = await node.execute(state)
+
+        assert result["summary"] == "요약"
+        mock_model.bind.assert_called_once_with(max_tokens=1234)
+        response_model.ainvoke.assert_awaited_once()


### PR DESCRIPTION
## Summary
- enforce explicit `@Name` mention routing for AI participants and add a regex fast-path before any LLM mention extraction
- remove AI mention fallback, keep a limited human-only fallback with a small token cap, and tighten task-model settings for utility work
- reduce summary churn and add regression coverage for routing, prompt contracts, settings, and summarize behavior

## Testing
- `uv run --extra server pytest -x -v`

## Trace Comparison
Baseline trace: `019cd77e-aed0-79a2-aa3c-8470d8e47a80`
Follow-up trace: `019cd7b4-0970-7271-880b-2a117e518f6d`

- total runtime: `153.5s -> 123.2s` (~19.8% faster)
- `process_response`: `106.5s -> 25.9s` (~75.7% reduction)
- LLM runs: `17 -> 14`
- reasoning tokens: `19107 -> 9567`

## Notes
- plain `uv run pytest -x -v` did not collect `tests/server/*` because the `server` extra was missing; validation used `--extra server`
- while validating this branch, a separate `--config` propagation bug was identified and tracked in #216

Closes #214.
