### PR TITLE
feat: add explicit host end command

### DIFF
--- a/doorae/graph/constants.py
+++ b/doorae/graph/constants.py
@@ -35,5 +35,8 @@ PARTICIPANT_STATUS_TEXT = {
 # Host 역할 이름
 HOST_ROLE_NAME = "Host"
 
+# AI Host가 회의를 종료할 때 출력해야 하는 마지막 줄 토큰
+HOST_END_MEETING_COMMAND = "[[HOST_END_MEETING]]"
+
 # 에이전트 색상 (동적 할당용)
 AGENT_COLORS = ["green", "blue", "yellow", "cyan", "magenta", "bright_white"]

--- a/doorae/graph/nodes/agent.py
+++ b/doorae/graph/nodes/agent.py
@@ -9,7 +9,12 @@ from doorae.agents.base_agent import BaseAgent
 from doorae.graph.nodes.base import BaseNode, NodeType
 from doorae.graph.nodes.registry import register_node
 from doorae.graph.state import MeetingState, ParticipantStatus
-from doorae.graph.constants import STATUS_EMOJI, STATUS_TEXT, HOST_ROLE_NAME
+from doorae.graph.constants import (
+    STATUS_EMOJI,
+    STATUS_TEXT,
+    HOST_ROLE_NAME,
+    HOST_END_MEETING_COMMAND,
+)
 from doorae.graph.agenda_tools import (
     create_propose_tool,
     create_approve_tool,
@@ -276,6 +281,20 @@ class AgentNode(BaseNode):
 
             metadata_section = "\n".join(metadata_lines)
 
+        host_end_protocol_section = ""
+        if self.profile.name == HOST_ROLE_NAME:
+            host_end_protocol_section = f"""
+
+## 회의 종료 프로토콜
+회의를 종료할 때만 마지막 줄에 아래 종료 커맨드를 정확히 한 줄로 출력하세요.
+마지막 비어있지 않은 줄은 반드시 이 토큰과 정확히 일치해야 합니다.
+평소 발언이나 안건 전환 중에는 이 토큰을 절대 출력하지 마세요.
+
+예시:
+오늘 회의는 여기까지 정리하겠습니다. 후속 작업은 문서로 공유드리겠습니다.
+{HOST_END_MEETING_COMMAND}
+            """
+
         return f"""당신은 {self.profile.name}, {self.profile.role}입니다.
 
 ## 책임
@@ -283,7 +302,7 @@ class AgentNode(BaseNode):
 
 ## 전문 분야
 {chr(10).join(f'- {e}' for e in self.profile.expertise)}
-{participants_section}{metadata_section}
+{participants_section}{metadata_section}{host_end_protocol_section}
 간결하고 전문적으로 한국어로 응답하세요."""
 
     def _format_agenda_context(

--- a/doorae/graph/nodes/process.py
+++ b/doorae/graph/nodes/process.py
@@ -10,7 +10,7 @@ from doorae.config import get_settings
 from doorae.graph.nodes.base import BaseNode, NodeType
 from doorae.graph.nodes.registry import register_node
 from doorae.graph.state import MeetingState
-from doorae.graph.constants import HOST_ROLE_NAME
+from doorae.graph.constants import HOST_ROLE_NAME, HOST_END_MEETING_COMMAND
 
 
 @register_node("process_response", category="utility")
@@ -184,31 +184,16 @@ class ProcessResponseNode(BaseNode):
         ]
         return any(kw in content for kw in end_keywords)
 
-    async def _detect_meeting_end_llm(self, content: str) -> bool:
-        """LLM으로 회의 종료 의도 분석
-
-        키워드 미감지 시 fallback으로 사용됩니다.
-
-        Args:
-            content: 발언 내용
-
-        Returns:
-            회의 종료 의도가 감지되면 True
-        """
-        prompt = f"""다음 Host의 발언이 회의를 종료하려는 의도인지 판단하세요.
-
-발언: "{content}"
-
-회의 종료 의도가 명확하면 "예", 아니면 "아니오"로만 답하세요:"""
-
-        try:
-            response = await self.model.bind(max_tokens=16).ainvoke(prompt)
-            result = response.content.strip()
-
-            return result == "예"
-        except Exception as e:
-            logger.warning(f"⚠️ 회의 종료 감지 LLM 호출 실패 (발언: {content[:30]}...): {type(e).__name__}: {e}")
+    def _detect_meeting_end_command(self, content: str) -> bool:
+        """마지막 비어있지 않은 줄이 종료 커맨드와 정확히 일치하는지 확인."""
+        if not content:
             return False
+
+        non_empty_lines = [line.strip() for line in content.splitlines() if line.strip()]
+        if not non_empty_lines:
+            return False
+
+        return non_empty_lines[-1] == HOST_END_MEETING_COMMAND
 
     async def execute(self, state: MeetingState) -> Dict[str, Any]:
         """에이전트 응답 처리
@@ -265,22 +250,13 @@ class ProcessResponseNode(BaseNode):
 
         # 6. Host 회의 종료 발언 감지 (안건 상태 무관)
         if speaker_name == HOST_ROLE_NAME:
-            # 1단계: 키워드 감지 (최우선, 안건 상태 무관)
-            if self._detect_meeting_end_keyword(content):
-                meeting_ended = True
-
-            # 2단계: LLM 분석 (키워드 미감지 + 안건 대부분 완료)
-            elif len(new_agendas) > 0:
-                completed_count = sum(
-                    1
-                    for a in new_agendas
-                    if a["status"] in ["completed", "deferred"]
+            if isinstance(last_msg, AIMessage):
+                meeting_ended = self._detect_meeting_end_command(content)
+            else:
+                meeting_ended = (
+                    self._detect_meeting_end_command(content)
+                    or self._detect_meeting_end_keyword(content)
                 )
-                completion_rate = completed_count / len(new_agendas)
-
-                # 80% 이상 완료 시에만 LLM 분석 (토큰 절약)
-                if completion_rate >= 0.8:
-                    meeting_ended = await self._detect_meeting_end_llm(content)
 
         # 턴 카운트 증가
         turn_count = state.get("turn_count", 0) + 1

--- a/tests/graph/nodes/test_agent_actions.py
+++ b/tests/graph/nodes/test_agent_actions.py
@@ -3,6 +3,7 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import cast
 
 from doorae.core.profile import AgentProfile
+from doorae.graph.constants import HOST_END_MEETING_COMMAND
 from doorae.graph.nodes.agent import AgentNode
 
 
@@ -37,6 +38,33 @@ def _create_prompt_node() -> AgentNode:
     )
     return AgentNode(
         profile=host,
+        model=MagicMock(),
+        all_agent_names=["Host", "PM", "TechLead"],
+        all_profiles={"Host": host, "PM": pm, "TechLead": techlead},
+    )
+
+
+def _create_non_host_prompt_node() -> AgentNode:
+    host = AgentProfile(
+        name="Host",
+        role="host",
+        responsibilities=["facilitate"],
+        expertise=["coordination"],
+    )
+    pm = AgentProfile(
+        name="PM",
+        role="pm",
+        responsibilities=["plan"],
+        expertise=["roadmap"],
+    )
+    techlead = AgentProfile(
+        name="TechLead",
+        role="tech_lead",
+        responsibilities=["review"],
+        expertise=["architecture"],
+    )
+    return AgentNode(
+        profile=pm,
         model=MagicMock(),
         all_agent_names=["Host", "PM", "TechLead"],
         all_profiles={"Host": host, "PM": pm, "TechLead": techlead},
@@ -193,3 +221,22 @@ def test_build_agent_prompt_requires_at_mentions():
     assert "@PM" in prompt
     assert "@TechLead" in prompt
     assert "반드시 @이름 형식" in prompt
+
+
+def test_build_agent_prompt_includes_host_end_command_contract():
+    node = _create_prompt_node()
+
+    prompt = node._build_agent_prompt()
+
+    assert HOST_END_MEETING_COMMAND in prompt
+    assert "회의를 종료할 때만 마지막 줄에" in prompt
+    assert "마지막 비어있지 않은 줄" in prompt
+
+
+def test_build_agent_prompt_excludes_host_end_command_for_non_host():
+    node = _create_non_host_prompt_node()
+
+    prompt = node._build_agent_prompt()
+
+    assert HOST_END_MEETING_COMMAND not in prompt
+    assert "회의를 종료할 때만 마지막 줄에" not in prompt

--- a/tests/graph/nodes/test_process.py
+++ b/tests/graph/nodes/test_process.py
@@ -4,6 +4,7 @@ import inspect
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 from unittest.mock import AsyncMock, MagicMock
+from doorae.graph.constants import HOST_END_MEETING_COMMAND
 from doorae.graph.nodes.process import ProcessResponseNode, NodeType
 
 
@@ -147,20 +148,38 @@ class TestProcessResponseNode:
         model.bind.assert_called_once_with(max_tokens=64)
         response_model.ainvoke.assert_awaited_once()
 
-    @pytest.mark.asyncio
-    async def test_detect_meeting_end_llm_uses_small_token_cap(self):
-        response_model = MagicMock()
-        response_model.ainvoke = AsyncMock(return_value=MagicMock(content="예"))
+    def test_process_response_node_has_no_meeting_end_llm_fallback(self):
+        """회의 종료 LLM fallback이 제거되었는지 확인"""
+        assert not hasattr(ProcessResponseNode, "_detect_meeting_end_llm")
 
-        model = MagicMock()
-        model.bind.return_value = response_model
-        node = ProcessResponseNode(model=model, valid_speakers=["Host"])
+    def test_detect_meeting_end_command_matches_exact_last_non_empty_line(self):
+        """종료 커맨드는 마지막 비어있지 않은 줄과 정확히 일치해야 함"""
+        node = ProcessResponseNode(model=MagicMock(), valid_speakers=["Host"])
 
-        result = await node._detect_meeting_end_llm("회의를 마칠까요?")
-
-        assert result is True
-        model.bind.assert_called_once_with(max_tokens=16)
-        response_model.ainvoke.assert_awaited_once()
+        assert (
+            node._detect_meeting_end_command(
+                f"오늘 논의는 여기까지 하겠습니다.\n{HOST_END_MEETING_COMMAND}"
+            )
+            is True
+        )
+        assert (
+            node._detect_meeting_end_command(
+                f"오늘 논의는 여기까지 하겠습니다.\n{HOST_END_MEETING_COMMAND}\n"
+            )
+            is True
+        )
+        assert (
+            node._detect_meeting_end_command(
+                f"{HOST_END_MEETING_COMMAND} 감사합니다."
+            )
+            is False
+        )
+        assert (
+            node._detect_meeting_end_command(
+                f"오늘 논의는 여기까지 하겠습니다. {HOST_END_MEETING_COMMAND}"
+            )
+            is False
+        )
 
     @pytest.mark.asyncio
     async def test_execute_routes_ai_mentions_into_pending_queue(self):
@@ -178,3 +197,83 @@ class TestProcessResponseNode:
 
         assert result["pending_speakers"] == ["PM"]
         assert result["speaker_counts"] == {"Host": 1}
+
+    @pytest.mark.asyncio
+    async def test_execute_ends_meeting_when_host_ai_message_has_explicit_command(self):
+        model = MagicMock()
+        node = ProcessResponseNode(model=model, valid_speakers=["Host", "PM"])
+        state = {
+            "messages": [
+                AIMessage(
+                    content=(
+                        "오늘 회의는 여기까지 정리하겠습니다.\n"
+                        f"{HOST_END_MEETING_COMMAND}"
+                    ),
+                    name="Host",
+                )
+            ],
+            "agendas": [{"title": "Test", "status": "in_progress"}],
+            "current_agenda_idx": 0,
+            "pending_speakers": ["Host"],
+            "speaker_counts": {},
+            "turn_count": 0,
+        }
+
+        result = await node.execute(state)
+
+        assert result["meeting_ended"] is True
+        model.bind.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_does_not_end_meeting_when_non_host_uses_explicit_command(self):
+        model = MagicMock()
+        node = ProcessResponseNode(model=model, valid_speakers=["Host", "PM"])
+        state = {
+            "messages": [AIMessage(content=HOST_END_MEETING_COMMAND, name="PM")],
+            "agendas": [{"title": "Test", "status": "in_progress"}],
+            "current_agenda_idx": 0,
+            "pending_speakers": ["PM"],
+            "speaker_counts": {},
+            "turn_count": 0,
+        }
+
+        result = await node.execute(state)
+
+        assert result["meeting_ended"] is False
+        model.bind.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_does_not_end_meeting_when_host_ai_message_has_only_keyword(self):
+        model = MagicMock()
+        node = ProcessResponseNode(model=model, valid_speakers=["Host", "PM"])
+        state = {
+            "messages": [AIMessage(content="회의를 마치겠습니다.", name="Host")],
+            "agendas": [{"title": "Test", "status": "completed"}],
+            "current_agenda_idx": 1,
+            "pending_speakers": ["Host"],
+            "speaker_counts": {},
+            "turn_count": 3,
+        }
+
+        result = await node.execute(state)
+
+        assert result["meeting_ended"] is False
+        model.bind.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_execute_allows_human_host_keyword_fallback(self):
+        model = MagicMock()
+        node = ProcessResponseNode(model=model, valid_speakers=["Host", "PM"])
+        state = {
+            "messages": [HumanMessage(content="회의를 마치겠습니다.", name="Host")],
+            "agendas": [{"title": "Test", "status": "completed"}],
+            "current_agenda_idx": 1,
+            "pending_speakers": ["Host"],
+            "speaker_counts": {},
+            "turn_count": 3,
+        }
+
+        result = await node.execute(state)
+
+        assert result["meeting_ended"] is True
+        model.bind.assert_not_called()

--- a/tests/graph/nodes/test_utils.py
+++ b/tests/graph/nodes/test_utils.py
@@ -4,7 +4,7 @@
 - extract_mentions_llm → ProcessResponseNode._extract_mentions (통합 테스트로 커버)
 - detect_agenda_completion → ProcessResponseNode._detect_agenda_completion (통합 테스트로 커버)
 - detect_meeting_end_keyword → ProcessResponseNode._detect_meeting_end_keyword (통합 테스트로 커버)
-- detect_meeting_end_llm → ProcessResponseNode._detect_meeting_end_llm (통합 테스트로 커버)
+- detect_meeting_end_command → ProcessResponseNode._detect_meeting_end_command (통합 테스트로 커버)
 - get_remaining_speakers → RefillSpeakersNode._get_remaining_speakers (통합 테스트로 커버)
 """
 


### PR DESCRIPTION
## Summary
- add a fixed `[[HOST_END_MEETING]]` sentinel for AI Host meeting termination
- replace the ProcessResponseNode meeting-end LLM fallback with deterministic command detection
- add Host-only prompt guidance and regression tests for command/fallback behavior

## Testing
- uv run pytest tests/graph/nodes/test_process.py -x -v
- uv run pytest tests/graph/nodes/test_agent_actions.py -x -v
- uv run pytest tests/graph -x -v

## Notes
- `uv run pytest -x -v` currently stops during collection because `fastapi` is missing in this environment (`tests/server/test_connection_manager.py`).

Closes #217