### PR TITLE
feat: run summarize and process_response in parallel (#215)

### DIFF
--- a/doorae/graph/workflow.py
+++ b/doorae/graph/workflow.py
@@ -3,7 +3,7 @@
 아키텍처:
 - pending_speakers 큐 기반 라우팅 (LLM 호출 최소화)
 - 안건(Agenda) 중심의 구조화된 회의 진행
-- LLM 기반 멘션 추출 및 의도 분석
+- summarize ∥ process_response 병렬 실행 (fan-out/fan-in)
 - Host 명시적 안건 완료 선언
 - AI 자동 안건 관리 (추가/수정/제거)
 """
@@ -110,34 +110,40 @@ def create_meeting_workflow(
         )
         workflow.add_node(name.lower(), node)
 
-    # 7. 진입점: refill_speakers
+    # 7. route_next 패스쓰루 노드 (fan-in join point)
+    workflow.add_node("route_next", lambda state: {})
+
+    # 8. 진입점: refill_speakers
     workflow.set_entry_point("refill_speakers")
 
-    # 8. 에이전트 → summarize → process_response
+    # 9. 에이전트 → [summarize ∥ process_response] (fan-out, 병렬 실행)
     for name in profiles.keys():
         workflow.add_edge(name.lower(), "summarize")
+        workflow.add_edge(name.lower(), "process_response")
 
-    workflow.add_edge("summarize", "process_response")
+    # 10. [summarize, process_response] → route_next (fan-in)
+    workflow.add_edge("summarize", "route_next")
+    workflow.add_edge("process_response", "route_next")
 
-    # 9. process_response → condition_router
+    # 11. route_next → condition_router
     available_targets = {name.lower(): name.lower() for name in profiles.keys()}
     available_targets["refill_speakers"] = "refill_speakers"
     available_targets[END] = END
 
     workflow.add_conditional_edges(
-        "process_response",
+        "route_next",
         condition_router,
         available_targets
     )
 
-    # 10. refill_speakers → condition_router
+    # 12. refill_speakers → condition_router
     workflow.add_conditional_edges(
         "refill_speakers",
         condition_router,
         available_targets
     )
 
-    # 11. 컴파일
+    # 13. 컴파일
     return workflow.compile()
 
 

--- a/tests/graph/test_workflow.py
+++ b/tests/graph/test_workflow.py
@@ -141,3 +141,57 @@ def test_create_meeting_workflow_integration():
     # 워크플로우가 정상적으로 생성되었는지 확인
     assert workflow is not None
     assert hasattr(workflow, "invoke") or hasattr(workflow, "ainvoke")
+
+
+def test_workflow_parallel_summarize_process():
+    """summarize와 process_response가 병렬로 실행되는 그래프 구조 테스트
+
+    각 에이전트 노드에서 summarize와 process_response로 fan-out되고,
+    두 노드 모두 route_next로 fan-in된 후 condition_router로 라우팅되어야 한다.
+    """
+    from doorae.graph.workflow import create_meeting_workflow
+
+    workflow = create_meeting_workflow()
+    graph = workflow.get_graph()
+
+    # 그래프에서 노드 이름 수집
+    node_names = {node.name for node in graph.nodes.values()}
+
+    # route_next 패스쓰루 노드가 존재해야 함
+    assert "route_next" in node_names, (
+        "route_next 패스쓰루 노드가 그래프에 존재해야 합니다"
+    )
+
+    # 에이전트 노드가 summarize와 process_response 둘 다로 연결되어야 함
+    # (직렬이 아닌 병렬 fan-out)
+    edges_by_source = {}
+    for edge in graph.edges:
+        src = edge.source.name if hasattr(edge.source, 'name') else str(edge.source)
+        tgt = edge.target.name if hasattr(edge.target, 'name') else str(edge.target)
+        edges_by_source.setdefault(src, set()).add(tgt)
+
+    # summarize → process_response 직렬 엣지가 없어야 함
+    summarize_targets = edges_by_source.get("summarize", set())
+    assert "process_response" not in summarize_targets, (
+        "summarize → process_response 직렬 엣지가 없어야 합니다 (병렬 구조)"
+    )
+
+    # summarize와 process_response 모두 route_next로 fan-in
+    assert "route_next" in summarize_targets, (
+        "summarize → route_next 엣지가 있어야 합니다"
+    )
+    process_targets = edges_by_source.get("process_response", set())
+    assert "route_next" in process_targets, (
+        "process_response → route_next 엣지가 있어야 합니다"
+    )
+
+    # 최소 하나의 에이전트 노드가 summarize와 process_response 둘 다로 fan-out
+    agent_fan_out_found = False
+    for src, targets in edges_by_source.items():
+        if "summarize" in targets and "process_response" in targets:
+            agent_fan_out_found = True
+            break
+
+    assert agent_fan_out_found, (
+        "최소 하나의 에이전트 노드가 summarize와 process_response로 fan-out해야 합니다"
+    )


### PR DESCRIPTION
## Summary

- Change workflow topology from serial (`agent → summarize → process_response`) to parallel fan-out/fan-in (`agent → [summarize ∥ process_response] → route_next`)
- The two nodes modify completely independent state fields, making parallel execution safe
- Add `route_next` passthrough node as the fan-in join point

## Performance

| Metric | Before (serial) | After (parallel) | Change |
|--------|-----------------|------------------|--------|
| Total runtime | 123.2s | 70.6s | **-42.7%** |
| Concurrent start | N/A | 8/8 pairs (0ms diff) | Perfect parallel |

Verified via LangSmith traces.

## Test plan

- [x] `test_workflow_parallel_summarize_process` — graph structure validation (fan-out/fan-in edges)
- [x] Full test suite passes (212 passed, 2 skipped)
- [x] Live meeting run + LangSmith trace confirms parallel execution

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>