### PR TITLE
fix: improve server mode TUI UX (#238)

### DIFF
--- a/doorae/interfaces/cli.py
+++ b/doorae/interfaces/cli.py
@@ -599,6 +599,8 @@ async def run_meeting(
                 server_url=server_session.ws_url if server_session else None,
                 server_start_url=server_session.start_url if server_session else None,
                 server_username=username,
+                room_id=server_session.room_id if server_session else None,
+                show_server_invite=server_session is not None and room_id is None,
             )
             await tui_app.run_async()
             return

--- a/doorae/interfaces/tui.py
+++ b/doorae/interfaces/tui.py
@@ -7,6 +7,7 @@ import colorsys
 import random
 import time
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import httpx
 from rich.markup import escape
@@ -256,6 +257,10 @@ class StreamError(Message):
     def __init__(self, error: str) -> None:
         super().__init__()
         self.error = error
+
+
+class ServerConnected(Message):
+    pass
 
 
 class TuiMeetingCallback:
@@ -519,6 +524,8 @@ class MeetingTuiApp(App[None]):
         server_url: str | None = None,
         server_start_url: str | None = None,
         server_username: str = "user",
+        room_id: str | None = None,
+        show_server_invite: bool = False,
     ) -> None:
         super().__init__()
         self._settings = settings
@@ -528,6 +535,8 @@ class MeetingTuiApp(App[None]):
         self._server_url = server_url
         self._server_start_url = server_start_url
         self._server_username = server_username
+        self._room_id = room_id
+        self._show_server_invite = show_server_invite
         self._engine: MeetingEngine | None = None
         self._workflow: Any = None
         self._initial_state: dict[str, object] = {}
@@ -547,6 +556,7 @@ class MeetingTuiApp(App[None]):
         self._full_text: str = ""
         self._ws_client: ServerEventClient | None = None
         self._server_start_attempted = False
+        self._connecting_spinner: SpinnerWidget | None = None
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -569,10 +579,14 @@ class MeetingTuiApp(App[None]):
             from doorae.interfaces.tui_ws_client import ServerEventClient
 
             participant_panel.initialize({}, {})
+            participant_panel.update_status(self._server_username, "idle")
             self._meeting_start_time = time.time()
             agenda_panel.update_meeting_start_time(self._meeting_start_time)
             agenda_panel.update_agendas(self._last_agendas, 0)
             self._timer_interval = self.set_interval(1.0, self._tick_timer)
+            self.sub_title = self._build_sub_title("")
+            self._mount_server_invite_notice()
+            self._mount_connecting_spinner()
             self._ws_client = ServerEventClient(
                 ws_url=self._server_url,
                 username=self._server_username,
@@ -639,8 +653,10 @@ class MeetingTuiApp(App[None]):
         try:
             self.meeting_status = "starting"
             if not await client.wait_until_connected(timeout=10.0):
+                self.post_message(StreamError(error="서버 연결 시간이 초과되었습니다."))
                 await client_task
                 return
+            self.post_message(ServerConnected())
             await self._start_remote_meeting()
             self.meeting_status = "running"
             await client_task
@@ -704,8 +720,50 @@ class MeetingTuiApp(App[None]):
         if bubble.display:
             scroll.scroll_end(animate=False)
 
+    def _build_sub_title(self, speaker: str) -> str:
+        parts: list[str] = []
+        if self._room_id:
+            parts.append(f"Room: {self._room_id}")
+        if speaker:
+            parts.append(f"발언자: {speaker}")
+        return " | ".join(parts)
+
+    def _mount_server_invite_notice(self) -> None:
+        if not self._show_server_invite:
+            return
+        invite_command = self._build_server_invite_command()
+        scroll = self._get_conversation_scroll()
+        if invite_command is None or scroll is None:
+            return
+        scroll.mount(Static(f"다른 참여자 초대:\n{invite_command}"))
+        scroll.scroll_end(animate=False)
+
+    def _mount_connecting_spinner(self) -> None:
+        scroll = self._get_conversation_scroll()
+        if scroll is None or self._connecting_spinner is not None:
+            return
+        self._connecting_spinner = SpinnerWidget("서버에 연결 중...")
+        scroll.mount(self._connecting_spinner)
+        scroll.scroll_end(animate=False)
+
+    def _clear_connecting_spinner(self) -> None:
+        if self._connecting_spinner is None:
+            return
+        self._connecting_spinner.remove()
+        self._connecting_spinner = None
+
+    def _build_server_invite_command(self) -> str | None:
+        if self._server_url is None or self._room_id is None:
+            return None
+
+        parsed = urlsplit(self._server_url)
+        room_path_suffix = f"/ws/{quote(self._room_id, safe='')}"
+        base_path = parsed.path.removesuffix(room_path_suffix)
+        base_url = urlunsplit((parsed.scheme, parsed.netloc, base_path.rstrip("/"), "", ""))
+        return f"doorae --server {base_url} --room {self._room_id} --username <name>"
+
     def watch_current_speaker(self, speaker: str) -> None:
-        self.sub_title = f"발언자: {speaker}" if speaker else ""
+        self.sub_title = self._build_sub_title(speaker)
 
     def watch_current_agenda_idx(self, idx: int) -> None:
         agenda_panel = self.query_one("#agenda-panel", AgendaPanel)
@@ -864,13 +922,24 @@ class MeetingTuiApp(App[None]):
     def on_meeting_ended(self, event: MeetingEnded) -> None:
         self._last_agendas = event.agendas
         self._last_speaker_counts = event.speaker_counts
+        self._clear_connecting_spinner()
         if self._timer_interval is not None:
             self._timer_interval.stop()
             self._timer_interval = None
         self._tick_timer()
         self.meeting_status = "ended"
 
+    def on_server_connected(self, event: ServerConnected) -> None:
+        _ = event
+        self._clear_connecting_spinner()
+        scroll = self._get_conversation_scroll()
+        if scroll is None:
+            return
+        scroll.mount(Static("서버에 연결되었습니다."))
+        scroll.scroll_end(animate=False)
+
     def on_stream_error(self, event: StreamError) -> None:
+        self._clear_connecting_spinner()
         if self._timer_interval is not None:
             self._timer_interval.stop()
             self._timer_interval = None

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -14,7 +14,13 @@ import yaml
 from typer.testing import CliRunner
 
 from doorae import PROJECT_ROOT
-from doorae.interfaces.cli import _normalize_server_base_urls, _setup_server_room, app
+from doorae.config import Settings
+from doorae.interfaces.cli import (
+    _normalize_server_base_urls,
+    _setup_server_room,
+    app,
+    run_meeting,
+)
 from doorae.project import WorkspaceError, init_workspace
 
 
@@ -156,6 +162,64 @@ async def test_setup_server_room_errors_for_missing_room(
 
     with pytest.raises(RuntimeError, match="회의방을 찾을 수 없습니다: missing-room"):
         await _setup_server_room("http://localhost:8000", "missing-room", "alice")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requested_room_id", "show_server_invite"),
+    [
+        (None, True),
+        ("existing-room", False),
+    ],
+)
+async def test_run_meeting_passes_server_room_metadata_to_tui(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    requested_room_id: str | None,
+    show_server_invite: bool,
+) -> None:
+    captured_kwargs: dict[str, Any] = {}
+
+    class StubMeetingTuiApp:
+        def __init__(self, **kwargs: Any) -> None:
+            captured_kwargs.update(kwargs)
+
+        async def run_async(self) -> None:
+            return
+
+    async def stub_setup_server_room(
+        server_url: str,
+        room_id: str | None,
+        username: str,
+    ) -> Any:
+        assert server_url == "ws://localhost:8000"
+        assert room_id == requested_room_id
+        assert username == "alice"
+        return type(
+            "ServerSession",
+            (),
+            {
+                "room_id": "room-123",
+                "ws_url": "ws://localhost:8000/ws/room-123?username=alice",
+                "start_url": "http://localhost:8000/api/rooms/room-123/start",
+            },
+        )()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("doorae.interfaces.cli._setup_server_room", stub_setup_server_room)
+    monkeypatch.setattr("doorae.interfaces.tui.MeetingTuiApp", StubMeetingTuiApp)
+
+    await run_meeting(
+        initial_message="hello",
+        settings=Settings(),
+        use_tui=True,
+        server_url="ws://localhost:8000",
+        room_id=requested_room_id,
+        username="alice",
+    )
+
+    assert captured_kwargs["room_id"] == "room-123"
+    assert captured_kwargs["show_server_invite"] is show_server_invite
 
 
 def test_init_command_is_visible_in_help() -> None:

--- a/tests/interfaces/test_tui.py
+++ b/tests/interfaces/test_tui.py
@@ -6,7 +6,15 @@ import pytest
 from textual.widgets import Input, Markdown, Static
 
 from doorae.config import Settings
-from doorae.interfaces.tui import HumanTurnStarted, MeetingTuiApp, SpeakerChanged, SpeechBubble
+from doorae.interfaces.tui import (
+    HumanTurnStarted,
+    MeetingTuiApp,
+    ParticipantPanel,
+    ServerConnected,
+    SpeakerChanged,
+    SpeechBubble,
+    SpinnerWidget,
+)
 
 
 class DummyMeetingTuiApp(MeetingTuiApp):
@@ -54,6 +62,11 @@ def _static_text(widget: Static) -> str:
 
 def _speaker_bubbles(app: MeetingTuiApp, speaker: str) -> list[SpeechBubble]:
     return [bubble for bubble in app.query(SpeechBubble) if bubble._speaker == speaker]
+
+
+def _conversation_texts(app: MeetingTuiApp) -> list[str]:
+    scroll = app.query_one("#conversation-scroll")
+    return [_static_text(widget) for widget in scroll.query(Static)]
 
 
 @pytest.mark.asyncio
@@ -193,6 +206,112 @@ async def test_server_mode_mount_uses_websocket_client(
         assert isinstance(app._ws_client, StubServerEventClient)
         assert app._ws_client.ws_url == "ws://localhost:8000/ws/room-123?username=alice"
         assert app.server_worker_called is True
+
+
+@pytest.mark.asyncio
+async def test_server_mode_mount_shows_room_and_initial_participant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubServerEventClient:
+        def __init__(self, ws_url: str, username: str, app: MeetingTuiApp) -> None:
+            self.ws_url = ws_url
+            self.username = username
+            self.app = app
+
+        async def close(self) -> None:
+            return
+
+    monkeypatch.setattr("doorae.interfaces.tui_ws_client.ServerEventClient", StubServerEventClient)
+
+    app = InspectServerBackedTuiApp(
+        settings=Settings(),
+        profiles_path="config/agent_profiles.yaml",
+        initial_message="hello",
+        server_url="ws://localhost:8000/ws/room-123?username=alice",
+        server_start_url="http://localhost:8000/api/rooms/room-123/start",
+        server_username="alice",
+        room_id="room-123",
+    )
+
+    async with app.run_test():
+        participant_panel = app.query_one("#participant-panel", ParticipantPanel)
+        assert app.sub_title == "Room: room-123"
+        assert participant_panel._statuses["alice"] == "idle"
+        assert "alice" in participant_panel._participant_nodes
+
+        app.on_speaker_changed(SpeakerChanged(speaker="host-agent", pending=[]))
+        assert app.sub_title == "Room: room-123 | 발언자: host-agent"
+
+
+@pytest.mark.asyncio
+async def test_server_mode_mount_shows_connecting_spinner_and_invite_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubServerEventClient:
+        def __init__(self, ws_url: str, username: str, app: MeetingTuiApp) -> None:
+            self.ws_url = ws_url
+            self.username = username
+            self.app = app
+
+        async def close(self) -> None:
+            return
+
+    monkeypatch.setattr("doorae.interfaces.tui_ws_client.ServerEventClient", StubServerEventClient)
+
+    app = InspectServerBackedTuiApp(
+        settings=Settings(),
+        profiles_path="config/agent_profiles.yaml",
+        initial_message="hello",
+        server_url="ws://localhost:8000/ws/room-123?username=alice",
+        server_start_url="http://localhost:8000/api/rooms/room-123/start",
+        server_username="alice",
+        room_id="room-123",
+        show_server_invite=True,
+    )
+
+    async with app.run_test():
+        spinners = [spinner for spinner in app.query(SpinnerWidget)]
+        assert len(spinners) == 1
+        assert spinners[0]._label == "서버에 연결 중..."
+        assert any(
+            "doorae --server ws://localhost:8000 --room room-123 --username <name>" in text
+            for text in _conversation_texts(app)
+        )
+
+
+@pytest.mark.asyncio
+async def test_server_connected_removes_spinner_and_shows_connected_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StubServerEventClient:
+        def __init__(self, ws_url: str, username: str, app: MeetingTuiApp) -> None:
+            self.ws_url = ws_url
+            self.username = username
+            self.app = app
+
+        async def close(self) -> None:
+            return
+
+    monkeypatch.setattr("doorae.interfaces.tui_ws_client.ServerEventClient", StubServerEventClient)
+
+    app = InspectServerBackedTuiApp(
+        settings=Settings(),
+        profiles_path="config/agent_profiles.yaml",
+        initial_message="hello",
+        server_url="ws://localhost:8000/ws/room-123?username=alice",
+        server_start_url="http://localhost:8000/api/rooms/room-123/start",
+        server_username="alice",
+        room_id="room-123",
+    )
+
+    async with app.run_test() as pilot:
+        assert len([spinner for spinner in app.query(SpinnerWidget)]) == 1
+
+        app.on_server_connected(ServerConnected())
+        await pilot.pause()
+
+        assert [spinner for spinner in app.query(SpinnerWidget)] == []
+        assert any("서버에 연결되었습니다." in text for text in _conversation_texts(app))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #238

## Summary
- show the server room id in the TUI header and keep it visible while the current speaker changes
- show invite instructions and connection status feedback when a server-backed room starts
- seed the participant panel with the local user and add regression tests for the new server-mode UX

## Testing
- uv run pytest tests/interfaces/test_tui.py tests/cli/test_main.py -x -v
- uv run --extra server pytest -x -v