### PR TITLE
fix: improve server mode error messages and CLI help text

### DIFF
--- a/doorae/interfaces/cli.py
+++ b/doorae/interfaces/cli.py
@@ -241,7 +241,9 @@ def _run_default_command(
         raise typer.Exit(code=0)
 
     if server and no_tui:
-        logger.warning("Ignoring --no-tui because server-backed mode requires the TUI")
+        logger.warning(
+            "--no-tui 옵션은 무시됩니다: 서버 모드는 TUI를 통해 WebSocket 이벤트를 표시합니다"
+        )
     use_tui = True if server else should_use_tui(no_tui)
     setup_logging(verbose=verbose, quiet=quiet, use_tui=use_tui)
 
@@ -256,19 +258,25 @@ def _run_default_command(
         endpoint=settings.langchain_endpoint,
     )
 
-    asyncio.run(
-        run_meeting(
-            initial_message=message,
-            profiles_path=profiles,
-            stream=stream,
-            settings=settings,
-            use_tui=use_tui,
-            server_url=server,
-            room_id=room,
-            username=username,
-            hide_delegated=hide_delegated,
+    try:
+        asyncio.run(
+            run_meeting(
+                initial_message=message,
+                profiles_path=profiles,
+                stream=stream,
+                settings=settings,
+                use_tui=use_tui,
+                server_url=server,
+                room_id=room,
+                username=username,
+                hide_delegated=hide_delegated,
+            )
         )
-    )
+    except RuntimeError as exc:
+        if server is not None:
+            console.print(f"[bold red]오류:[/bold red] {exc}")
+            raise typer.Exit(code=1) from exc
+        raise
 
 
 @app.callback(invoke_without_command=True)
@@ -302,19 +310,19 @@ def main(
         None,
         "--server",
         "-s",
-        help="서버 기본 URL (예: ws://localhost:8000 또는 http://localhost:8000)",
+        help="서버 모드 URL (예: http://localhost:8000). 먼저 서버를 실행하세요: uv run doorae-server",
     ),
     room: Optional[str] = typer.Option(
         None,
         "--room",
         "-r",
-        help="서버 모드에서 연결할 회의방 ID",
+        help="연결할 회의방 ID (생략 시 새 회의방 자동 생성)",
     ),
     username: str = typer.Option(
         "user",
         "--username",
         "-u",
-        help="서버 모드에서 사용할 사용자 이름",
+        help="서버 모드에서 표시될 사용자 이름",
     ),
     config: Optional[Path] = typer.Option(
         None,
@@ -471,7 +479,8 @@ def _normalize_server_base_urls(server_url: str) -> tuple[str, str]:
     parsed = urlsplit(server_url)
     if parsed.scheme not in {"ws", "wss", "http", "https"}:
         raise RuntimeError(
-            "지원하지 않는 서버 URL 스킴입니다. ws://, wss://, http://, https:// 중 하나를 사용하세요."
+            "지원하지 않는 서버 URL 스킴입니다."
+            "\n  → 예: http://localhost:8000"
         )
     if not parsed.netloc:
         raise RuntimeError("서버 URL에 호스트가 없습니다.")
@@ -505,26 +514,42 @@ async def _setup_server_room(
     """Create or validate the target room and build the concrete URLs for TUI mode."""
     ws_base, http_base = _normalize_server_base_urls(server_url)
 
-    async with httpx.AsyncClient(base_url=http_base, timeout=10.0) as client:
-        if room_id is None:
-            create_response = await client.post(
-                "/api/rooms",
-                json={"name": f"Doorae Room ({username})"},
-            )
-            if create_response.is_error:
-                raise RuntimeError(
-                    f"회의방 생성에 실패했습니다: {_extract_error_detail(create_response)}"
+    try:
+        async with httpx.AsyncClient(base_url=http_base, timeout=10.0) as client:
+            if room_id is None:
+                create_response = await client.post(
+                    "/api/rooms",
+                    json={"name": f"Doorae Room ({username})"},
                 )
-            payload = create_response.json()
-            room_id = str(payload["id"])
-        else:
-            room_response = await client.get(f"/api/rooms/{quote(room_id, safe='')}")
-            if room_response.status_code == 404:
-                raise RuntimeError(f"회의방을 찾을 수 없습니다: {room_id}")
-            if room_response.is_error:
-                raise RuntimeError(
-                    f"회의방 조회에 실패했습니다: {_extract_error_detail(room_response)}"
-                )
+                if create_response.is_error:
+                    raise RuntimeError(
+                        f"회의방 생성에 실패했습니다: {_extract_error_detail(create_response)}"
+                    )
+                payload = create_response.json()
+                room_id = str(payload["id"])
+            else:
+                room_response = await client.get(f"/api/rooms/{quote(room_id, safe='')}")
+                if room_response.status_code == 404:
+                    raise RuntimeError(
+                        f"회의방을 찾을 수 없습니다: {room_id}"
+                        "\n  → --room을 생략하면 새 회의방이 자동 생성됩니다"
+                    )
+                if room_response.is_error:
+                    raise RuntimeError(
+                        f"회의방 조회에 실패했습니다: {_extract_error_detail(room_response)}"
+                    )
+    except httpx.ConnectError:
+        raise RuntimeError(
+            f"서버에 연결할 수 없습니다: {http_base}"
+            "\n  → 서버가 실행 중인지 확인하세요: uv run doorae-server"
+        )
+    except RuntimeError:
+        raise
+    except httpx.HTTPError as exc:
+        raise RuntimeError(
+            f"서버 통신 중 오류가 발생했습니다: {exc}"
+            "\n  → 서버가 실행 중인지 확인하세요: uv run doorae-server"
+        ) from exc
 
     quoted_room_id = quote(room_id, safe="")
     quoted_username = quote(username, safe="")

--- a/doorae/interfaces/tui_ws_client.py
+++ b/doorae/interfaces/tui_ws_client.py
@@ -26,6 +26,21 @@ if TYPE_CHECKING:
     from doorae.interfaces.tui import MeetingTuiApp
 
 
+def _format_connection_closed(exc: ConnectionClosed) -> str:
+    """Convert a ConnectionClosed exception into a user-friendly Korean message."""
+    rcvd = getattr(exc, "rcvd", None)
+    code = getattr(rcvd, "code", None) if rcvd is not None else None
+    if code == 1000:
+        return "서버 연결이 정상적으로 종료되었습니다."
+    if code == 1001:
+        return "서버가 종료되었습니다."
+    if code == 1006:
+        return "서버 연결이 비정상적으로 종료되었습니다. 서버 상태를 확인하세요."
+    if code is not None:
+        return f"서버 연결이 종료되었습니다 (코드: {code})."
+    return "서버 연결이 종료되었습니다."
+
+
 class ServerEventClient:
     """Receive semantic room events and adapt them into existing TUI messages."""
 
@@ -52,7 +67,7 @@ class ServerEventClient:
                     try:
                         raw_message = await websocket.recv()
                     except ConnectionClosed as exc:
-                        self._emit_error(f"서버 연결이 종료되었습니다: {exc}")
+                        self._emit_error(_format_connection_closed(exc))
                         return
                     except StopAsyncIteration:
                         self._emit_error("서버 연결이 종료되었습니다.")
@@ -92,7 +107,7 @@ class ServerEventClient:
         try:
             await self._websocket.send(json.dumps({"content": content}))
         except ConnectionClosed as exc:
-            self._emit_error(f"입력 전송 중 연결이 종료되었습니다: {exc}")
+            self._emit_error(f"입력 전송 중 {_format_connection_closed(exc)}")
         except Exception as exc:
             self._emit_error(f"입력 전송 실패: {exc}")
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import httpx
 import pytest
 import yaml
 from typer.testing import CliRunner
@@ -57,6 +58,20 @@ def test_cli_help() -> None:
     assert "--server" in result.stdout
     assert "--room" in result.stdout
     assert "--username" in result.stdout
+
+
+def test_cli_help_server_option_includes_startup_hint() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "doorae-server" in result.stdout
+
+
+def test_cli_help_room_option_includes_auto_create_hint() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    # typer may line-wrap the help text, so check for key fragments
+    assert "생략" in result.stdout
+    assert "생성" in result.stdout
 
 
 def test_cli_default_message() -> None:
@@ -154,8 +169,65 @@ async def test_setup_server_room_errors_for_missing_room(
 
     monkeypatch.setattr("doorae.interfaces.cli.httpx.AsyncClient", MockAsyncClient)
 
-    with pytest.raises(RuntimeError, match="회의방을 찾을 수 없습니다: missing-room"):
+    with pytest.raises(RuntimeError, match="회의방을 찾을 수 없습니다: missing-room") as exc_info:
         await _setup_server_room("http://localhost:8000", "missing-room", "alice")
+
+    assert "--room" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_setup_server_room_connection_refused_includes_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MockAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> "MockAsyncClient":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def post(self, path: str, json: dict[str, Any]) -> MockResponse:
+            raise httpx.ConnectError("Connection refused")
+
+    monkeypatch.setattr("doorae.interfaces.cli.httpx.AsyncClient", MockAsyncClient)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await _setup_server_room("http://localhost:9999", None, "alice")
+
+    msg = str(exc_info.value)
+    assert "연결할 수 없습니다" in msg
+    assert "doorae-server" in msg
+
+
+def test_normalize_server_base_urls_invalid_scheme_includes_hint() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        _normalize_server_base_urls("ftp://localhost:8000")
+
+    msg = str(exc_info.value)
+    assert "http://localhost:8000" in msg
+
+
+def test_run_default_command_catches_server_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Server RuntimeError should produce exit code 1, not a traceback."""
+    error_msg = "서버에 연결할 수 없습니다: http://localhost:9999"
+
+    async def fake_run_meeting(**kwargs: Any) -> None:
+        raise RuntimeError(error_msg)
+
+    monkeypatch.setattr("doorae.interfaces.cli.run_meeting", fake_run_meeting)
+
+    result = runner.invoke(
+        app,
+        ["--server", "http://localhost:9999"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 1
+    assert "연결할 수 없습니다" in result.stdout
+    assert "Traceback" not in result.stdout
 
 
 def test_init_command_is_visible_in_help() -> None:

--- a/tests/interfaces/test_tui_ws_client.py
+++ b/tests/interfaces/test_tui_ws_client.py
@@ -7,6 +7,8 @@ import json
 from unittest.mock import AsyncMock
 
 import pytest
+from websockets.exceptions import ConnectionClosed
+from websockets.frames import Close
 
 from doorae.interfaces.tui import (
     AgendaUpdated,
@@ -20,7 +22,7 @@ from doorae.interfaces.tui import (
     ToolCallStarted,
     TurnCompleted,
 )
-from doorae.interfaces.tui_ws_client import ServerEventClient
+from doorae.interfaces.tui_ws_client import ServerEventClient, _format_connection_closed
 
 
 class RecordingApp:
@@ -312,3 +314,79 @@ async def test_wait_until_connected_tracks_connection_lifecycle(
     await run_task
 
     assert client.connected.is_set() is False
+
+
+def test_format_connection_closed_code_1006() -> None:
+    exc = ConnectionClosed(Close(1006, ""), None)
+    msg = _format_connection_closed(exc)
+    assert "비정상" in msg
+    assert "서버 상태를 확인" in msg
+
+
+def test_format_connection_closed_code_1000() -> None:
+    exc = ConnectionClosed(Close(1000, ""), None)
+    msg = _format_connection_closed(exc)
+    assert "정상" in msg
+
+
+def test_format_connection_closed_code_1001() -> None:
+    exc = ConnectionClosed(Close(1001, "going away"), None)
+    msg = _format_connection_closed(exc)
+    assert "서버가 종료" in msg
+
+
+def test_format_connection_closed_unknown_code() -> None:
+    exc = ConnectionClosed(Close(1011, "server error"), None)
+    msg = _format_connection_closed(exc)
+    assert "1011" in msg
+    assert "종료" in msg
+
+
+def test_format_connection_closed_no_rcvd() -> None:
+    exc = ConnectionClosed(None, None)
+    msg = _format_connection_closed(exc)
+    assert "종료" in msg
+
+
+@pytest.mark.asyncio
+async def test_run_formats_connection_closed_without_internal_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ConnectionClosed with code 1006 should produce a user-friendly message, not raw code."""
+    app = RecordingApp()
+    websocket = AsyncMock()
+
+    websocket.recv = AsyncMock(
+        side_effect=ConnectionClosed(Close(1006, "connection closed abnormally"), None)
+    )
+    _patch_connect(monkeypatch, MockConnection(websocket=websocket))
+
+    client = ServerEventClient("ws://example/ws/room?username=alice", "alice", app)
+    await client.run()
+
+    assert len(app.messages) == 1
+    error = app.messages[0]
+    assert isinstance(error, StreamError)
+    assert "1006" not in error.error
+    assert "비정상" in error.error
+
+
+@pytest.mark.asyncio
+async def test_send_input_formats_connection_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """send_input ConnectionClosed should use user-friendly message."""
+    app = RecordingApp()
+    client = ServerEventClient("ws://example/ws/room?username=alice", "alice", app)
+    websocket = AsyncMock()
+    websocket.send = AsyncMock(
+        side_effect=ConnectionClosed(Close(1006, ""), None)
+    )
+    client._websocket = websocket
+
+    await client.send_input("test")
+
+    assert len(app.messages) == 1
+    error = app.messages[0]
+    assert isinstance(error, StreamError)
+    assert "1006" not in error.error


### PR DESCRIPTION
## Summary
- WebSocket 끊김 시 내부 코드(1006 등) 대신 사용자 친화적 한국어 메시지 표시
- 서버 연결 실패 시 traceback 대신 복구 힌트 포함 에러 메시지 출력 (`uv run doorae-server`)
- `--server`, `--room`, `--username` CLI help 문자열 보강 (서버 시작 안내, 자동 생성 안내)

## Test plan
- [x] `_format_connection_closed()` 단위 테스트 (코드 1000/1001/1006/unknown/None)
- [x] WebSocket `ConnectionClosed` 통합 테스트 (run, send_input)
- [x] `_setup_server_room` 연결 실패 힌트 테스트
- [x] `_run_default_command` RuntimeError 처리 테스트
- [x] CLI help 문자열 검증 테스트
- [x] 전체 테스트 234 passed, 2 skipped

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)