### PR TITLE
feat: add doorae serve subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,13 +192,50 @@ User ──► CLI/TUI ──► LangGraph StateGraph
 
 AI participants must call other participants with `@Name` prefixes such as `@PM` or `@TechLead`. The routing layer treats AI responses without `@Name` as non-routing text and only keeps natural-language fallback for human input during the migration period.
 
-## WebSocket Server
+## Server Mode
 
-For web integrations, Doorae also provides a FastAPI WebSocket server:
+For web integrations and shared rooms, Doorae can run in client/server mode with a
+FastAPI WebSocket backend:
 
 ```bash
 uv sync --extra server
+uv run doorae serve --port 8000
+```
+
+The legacy entrypoint still works for compatibility, but it is deprecated:
+
+```bash
 uv run doorae-server
+```
+
+### Multi-participant flow
+
+1. Start the server:
+
+   ```bash
+   uv run doorae serve --host 0.0.0.0 --port 8000
+   ```
+
+2. Alice creates a room by connecting without `--room`:
+
+   ```bash
+   uv run doorae --server http://localhost:8000 --username alice
+   ```
+
+3. Bob joins the same room with the shared room ID:
+
+   ```bash
+   uv run doorae --server http://localhost:8000 --room <room_id> --username bob
+   ```
+
+```text
+Alice client                 Doorae server                  Bob client
+------------                 -------------                  ----------
+doorae serve --------------> listen on :8000
+doorae --server -----------> create room
+share <room_id> ------------------------------------------> receive room ID
+message stream <----------> /ws/<room_id>?username=alice
+                                                   /ws/<room_id>?username=bob <----------> message stream
 ```
 
 ## Development

--- a/doorae/interfaces/cli.py
+++ b/doorae/interfaces/cli.py
@@ -9,7 +9,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional
 from urllib.parse import quote, urlsplit, urlunsplit
 
 import httpx
@@ -37,6 +37,7 @@ app = typer.Typer(
 )
 console = Console()
 DEFAULT_MESSAGE = "회의를 시작합니다"
+OPTIONAL_SERVER_DEPENDENCIES = {"fastapi", "starlette", "uvicorn"}
 
 
 @dataclass(slots=True)
@@ -271,6 +272,26 @@ def _run_default_command(
     )
 
 
+def _load_server_runner() -> Callable[[str, int], None]:
+    """Load the server runtime lazily so the base CLI works without server extras."""
+    try:
+        from doorae.server import run_server
+        from doorae.server.app import create_app
+    except ImportError as exc:
+        missing_module = (exc.name or "").split(".")[0]
+        if missing_module in OPTIONAL_SERVER_DEPENDENCIES:
+            typer.secho(
+                "Server mode requires optional dependencies. Run 'uv sync --extra server'.",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(code=1) from exc
+        raise
+
+    _ = create_app
+    return run_server
+
+
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
@@ -398,6 +419,28 @@ def init_command(
         typer.echo("Created .env from the packaged template.")
     else:
         typer.echo("Kept existing .env.")
+
+
+@app.command("serve")
+def serve_command(
+    host: str = typer.Option(
+        "0.0.0.0",
+        "--host",
+        "-H",
+        envvar="SERVER_HOST",
+        help="바인딩할 호스트 주소",
+    ),
+    port: int = typer.Option(
+        8000,
+        "--port",
+        "-p",
+        envvar="SERVER_PORT",
+        help="서버 포트",
+    ),
+) -> None:
+    """Doorae WebSocket 서버를 시작한다."""
+    run_server = _load_server_runner()
+    run_server(host=host, port=port)
 
 
 async def _initialize_mcp(settings: Settings, use_tui: bool = False) -> dict[str, list] | None:

--- a/doorae/server/__init__.py
+++ b/doorae/server/__init__.py
@@ -4,17 +4,35 @@ doorae.server - WebSocket 채팅 서버
 LangGraph 워크플로우 기반 실시간 회의 채팅 서버
 """
 
-import uvicorn
+from __future__ import annotations
+
+import sys
+import warnings
+
 from doorae.server.config import get_server_settings
 
+DEPRECATED_ENTRYPOINT_MESSAGE = (
+    "doorae-server는 deprecated입니다. 대신 'doorae serve'를 사용하세요."
+)
 
-def main():
-    """서버 엔트리포인트."""
-    settings = get_server_settings()
+
+def run_server(host: str = "0.0.0.0", port: int = 8000) -> None:
+    """공통 서버 실행 로직."""
+    import uvicorn
+
     uvicorn.run(
         "doorae.server.app:create_app",
-        host=settings.host,
-        port=settings.port,
+        host=host,
+        port=port,
         factory=True,
         reload=False,
     )
+
+
+def main() -> None:
+    """서버 엔트리포인트."""
+    warnings.warn(DEPRECATED_ENTRYPOINT_MESSAGE, DeprecationWarning, stacklevel=2)
+    print(DEPRECATED_ENTRYPOINT_MESSAGE, file=sys.stderr)
+
+    settings = get_server_settings()
+    run_server(host=settings.host, port=settings.port)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
 
 [project.scripts]
 doorae = "doorae.interfaces.cli:app"
+# Deprecated compatibility shim. Prefer `doorae serve`.
 doorae-server = "doorae.server:main"
 
 [project.optional-dependencies]

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -53,6 +53,7 @@ def test_cli_help() -> None:
     assert result.exit_code == 0
     assert "Doorae" in result.stdout
     assert "init" in result.stdout
+    assert "serve" in result.stdout
     assert "--message" in result.stdout
     assert "--server" in result.stdout
     assert "--room" in result.stdout
@@ -164,6 +165,49 @@ def test_init_command_is_visible_in_help() -> None:
     assert "--force" in result.stdout
 
 
+def test_serve_command_is_visible_in_help() -> None:
+    result = runner.invoke(app, ["serve", "--help"])
+    assert result.exit_code == 0
+    assert "--host" in result.stdout
+    assert "--port" in result.stdout
+
+
+def test_serve_command_runs_server_with_explicit_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_run_server(*, host: str, port: int) -> None:
+        calls["host"] = host
+        calls["port"] = port
+
+    monkeypatch.setattr("doorae.interfaces.cli._load_server_runner", lambda: fake_run_server)
+
+    result = runner.invoke(app, ["serve", "--host", "127.0.0.1", "--port", "9000"])
+
+    assert result.exit_code == 0
+    assert calls == {"host": "127.0.0.1", "port": 9000}
+
+
+def test_serve_command_reads_host_and_port_from_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_run_server(*, host: str, port: int) -> None:
+        calls["host"] = host
+        calls["port"] = port
+
+    monkeypatch.setattr("doorae.interfaces.cli._load_server_runner", lambda: fake_run_server)
+    monkeypatch.setenv("SERVER_HOST", "127.0.0.1")
+    monkeypatch.setenv("SERVER_PORT", "9100")
+
+    result = runner.invoke(app, ["serve"])
+
+    assert result.exit_code == 0
+    assert calls == {"host": "127.0.0.1", "port": 9100}
+
+
 def test_python_module_help_stays_side_effect_free() -> None:
     result = subprocess.run(
         [sys.executable, "-m", "doorae", "--help"],
@@ -178,6 +222,25 @@ def test_python_module_help_stays_side_effect_free() -> None:
     combined_output = result.stdout + result.stderr
     assert result.returncode == 0
     assert "init" in result.stdout
+    assert "| DEBUG    |" not in combined_output
+    assert "노드 등록" not in combined_output
+
+
+def test_python_module_serve_help_stays_side_effect_free() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "doorae", "serve", "--help"],
+        cwd=PROJECT_ROOT,
+        env=build_subprocess_env(),
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+    combined_output = result.stdout + result.stderr
+    assert result.returncode == 0
+    assert "--host" in result.stdout
+    assert "--port" in result.stdout
     assert "| DEBUG    |" not in combined_output
     assert "노드 등록" not in combined_output
 

--- a/tests/server/test_entrypoint.py
+++ b/tests/server/test_entrypoint.py
@@ -1,0 +1,61 @@
+"""Server entrypoint tests."""
+
+from __future__ import annotations
+
+import sys
+import types
+import warnings
+
+import doorae.server as server_module
+
+
+def test_run_server_invokes_uvicorn_with_factory_mode(
+    monkeypatch,
+) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_uvicorn_run(*args, **kwargs) -> None:
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+
+    monkeypatch.setitem(sys.modules, "uvicorn", types.SimpleNamespace(run=fake_uvicorn_run))
+
+    server_module.run_server(host="127.0.0.1", port=9100)
+
+    assert calls["args"] == ("doorae.server.app:create_app",)
+    assert calls["kwargs"] == {
+        "host": "127.0.0.1",
+        "port": 9100,
+        "factory": True,
+        "reload": False,
+    }
+
+
+def test_legacy_main_warns_and_delegates_to_run_server(
+    monkeypatch,
+    capsys,
+) -> None:
+    calls: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        server_module,
+        "get_server_settings",
+        lambda: types.SimpleNamespace(host="127.0.0.1", port=9200),
+    )
+    monkeypatch.setattr(
+        server_module,
+        "run_server",
+        lambda *, host, port: calls.update({"host": host, "port": port}),
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        server_module.main()
+
+    captured = capsys.readouterr()
+    assert calls == {"host": "127.0.0.1", "port": 9200}
+    assert "doorae-server는 deprecated입니다." in captured.err
+    assert any(
+        warning.category is DeprecationWarning and "doorae serve" in str(warning.message)
+        for warning in caught
+    )


### PR DESCRIPTION
Closes #240

## Summary
- add a `doorae serve` subcommand with `--host` and `--port` options
- keep `doorae-server` as a deprecated compatibility entrypoint backed by shared `run_server()` logic
- expand README server mode docs with the multi-participant client/server flow
- add CLI and server entrypoint tests for help output, envvar loading, and legacy warnings

## Testing
- uv run --extra server pytest -x -v