### PR TITLE
fix: broadcast agent hierarchy to clients in server mode (#248)

### DIFF
--- a/doorae/interfaces/tui.py
+++ b/doorae/interfaces/tui.py
@@ -259,6 +259,12 @@ class StreamError(Message):
         self.error = error
 
 
+class AgentProfilesReceived(Message):
+    def __init__(self, top_profiles_data: dict[str, dict]) -> None:
+        super().__init__()
+        self.top_profiles_data = top_profiles_data
+
+
 class ServerConnected(Message):
     pass
 
@@ -953,6 +959,17 @@ class MeetingTuiApp(App[None]):
             return
         scroll.mount(Static("서버에 연결되었습니다."))
         scroll.scroll_end(animate=False)
+
+    def on_agent_profiles_received(self, event: AgentProfilesReceived) -> None:
+        from doorae.core.profile import AgentProfile, flatten_all_profiles
+
+        top_profiles = {
+            name: AgentProfile.model_validate(data)
+            for name, data in event.top_profiles_data.items()
+        }
+        all_profiles = flatten_all_profiles(top_profiles)
+        participant_panel = self.query_one("#participant-panel", ParticipantPanel)
+        participant_panel.initialize(top_profiles, all_profiles)
 
     def on_stream_error(self, event: StreamError) -> None:
         self._clear_connecting_spinner()

--- a/doorae/interfaces/tui_ws_client.py
+++ b/doorae/interfaces/tui_ws_client.py
@@ -11,6 +11,7 @@ from websockets.exceptions import ConnectionClosed
 
 from doorae.interfaces.tui import (
     AgendaUpdated,
+    AgentProfilesReceived,
     HumanTurnStarted,
     MeetingEnded,
     ParticipantStatusChanged,
@@ -135,6 +136,14 @@ class ServerEventClient:
         if not isinstance(data, dict):
             data = {}
         semantic_type = event_type.removeprefix("semantic:")
+
+        if semantic_type == "agent_profiles":
+            top_profiles = data.get("top_profiles")
+            if isinstance(top_profiles, dict):
+                self._app.post_message(
+                    AgentProfilesReceived(top_profiles_data=top_profiles)
+                )
+            return
 
         if semantic_type == "speaker_changed":
             speaker = data.get("speaker")

--- a/doorae/server/room.py
+++ b/doorae/server/room.py
@@ -365,6 +365,29 @@ class Room:
     async def _stream_engine_events(self, engine: MeetingEngine):
         """MeetingEngine 이벤트를 스트리밍하여 브로드캐스트."""
         try:
+            # Ensure setup is complete and broadcast profiles to clients
+            setup_state = engine.setup_state
+            if setup_state is None:
+                setup_state = engine.setup()
+
+            # Broadcast agent profiles to all clients (strip llm recursively)
+            def _strip_llm(d: dict) -> dict:
+                d.pop("llm", None)
+                for child in d.get("agents") or []:
+                    if isinstance(child, dict):
+                        _strip_llm(child)
+                return d
+
+            top_profiles_data = {
+                name: _strip_llm(profile.model_dump())
+                for name, profile in setup_state.top_profiles.items()
+            }
+            profiles_event = format_semantic_event(
+                "agent_profiles",
+                top_profiles=top_profiles_data,
+            )
+            await self.connection_manager.broadcast(json.dumps(profiles_event))
+
             await engine.run(ServerMeetingCallback(self.connection_manager, room=self))
         except asyncio.CancelledError:
             logger.info(f"Workflow streaming cancelled for room {self.id}")

--- a/tests/core/test_profile.py
+++ b/tests/core/test_profile.py
@@ -232,3 +232,68 @@ def test_agent_llm_config_unset_env_var_becomes_none(monkeypatch):
     )
 
     assert config.api_key is None
+
+
+def test_agent_profile_hierarchy_roundtrip():
+    """계층적 프로필 직렬화/역직렬화 라운드트립 테스트."""
+    supervisor = AgentProfile(
+        name="PM팀장",
+        role="project_manager",
+        responsibilities=["프로젝트 관리"],
+        expertise=["일정 관리"],
+        agents=[
+            AgentProfile(
+                name="기획자",
+                role="planner",
+                responsibilities=["기획"],
+                expertise=["기획"],
+            ),
+            AgentProfile(
+                name="디자이너",
+                role="designer",
+                responsibilities=["디자인"],
+                expertise=["UI/UX"],
+            ),
+        ],
+    )
+
+    # Serialize
+    dumped = supervisor.model_dump(exclude={"llm"})
+
+    # Deserialize
+    restored = AgentProfile.model_validate(dumped)
+
+    assert restored.name == "PM팀장"
+    assert len(restored.agents) == 2
+    assert restored.agents[0].name == "기획자"
+    assert restored.agents[1].name == "디자이너"
+    assert restored.is_supervisor()
+
+
+def test_agent_profile_hierarchy_flatten_after_roundtrip():
+    """라운드트립 후 flatten이 정상 동작하는지 테스트."""
+    profiles = {
+        "PM팀장": AgentProfile(
+            name="PM팀장",
+            role="project_manager",
+            responsibilities=["프로젝트 관리"],
+            expertise=["일정 관리"],
+            agents=[
+                AgentProfile(
+                    name="기획자",
+                    role="planner",
+                    responsibilities=["기획"],
+                    expertise=["기획"],
+                ),
+            ],
+        ),
+    }
+
+    # Serialize and deserialize
+    serialized = {name: p.model_dump(exclude={"llm"}) for name, p in profiles.items()}
+    restored = {name: AgentProfile.model_validate(d) for name, d in serialized.items()}
+
+    # Flatten should work
+    flat = flatten_all_profiles(restored)
+    assert "PM팀장" in flat
+    assert "기획자" in flat

--- a/tests/interfaces/test_tui_ws_client.py
+++ b/tests/interfaces/test_tui_ws_client.py
@@ -12,6 +12,7 @@ from websockets.frames import Close
 
 from doorae.interfaces.tui import (
     AgendaUpdated,
+    AgentProfilesReceived,
     HumanTurnStarted,
     MeetingEnded,
     ParticipantStatusChanged,
@@ -431,3 +432,37 @@ async def test_dispatch_user_joined() -> None:
     assert len(status_msgs) == 1
     assert status_msgs[0].participant_name == "Charlie"
     assert status_msgs[0].status == "idle"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_agent_profiles() -> None:
+    """agent_profiles 이벤트 수신 시 AgentProfilesReceived 메시지가 포스트되는지 테스트."""
+    app = RecordingApp()
+    client = ServerEventClient(ws_url="ws://test", username="test", app=app)
+
+    event = {
+        "type": "semantic:agent_profiles",
+        "data": {
+            "top_profiles": {
+                "PM팀장": {
+                    "name": "PM팀장",
+                    "role": "project_manager",
+                    "responsibilities": ["프로젝트 관리"],
+                    "expertise": ["일정 관리"],
+                    "agents": [
+                        {
+                            "name": "기획자",
+                            "role": "planner",
+                            "responsibilities": ["기획"],
+                            "expertise": ["기획"],
+                        }
+                    ],
+                }
+            }
+        },
+    }
+    await client._dispatch_event(event)
+
+    profile_msgs = [m for m in app.messages if isinstance(m, AgentProfilesReceived)]
+    assert len(profile_msgs) == 1
+    assert "PM팀장" in profile_msgs[0].top_profiles_data

--- a/tests/server/test_streaming.py
+++ b/tests/server/test_streaming.py
@@ -202,7 +202,14 @@ async def test_start_workflow_streaming_with_engine_broadcasts_raw_events():
     room = Room(room_id="test-room", name="Test Room")
     room.connection_manager.broadcast = AsyncMock()
 
+    class MockSetupState:
+        def __init__(self):
+            self.top_profiles = {}
+
     class MockEngine:
+        def __init__(self):
+            self.setup_state = MockSetupState()
+
         async def run(self, callback):
             await callback.on_raw_event({"event": "on_chain_start", "data": {}})
 
@@ -211,6 +218,9 @@ async def test_start_workflow_streaming_with_engine_broadcasts_raw_events():
     assert room._streaming_task is not None
     await room._streaming_task
 
-    room.connection_manager.broadcast.assert_called_once()
-    event_data = json.loads(room.connection_manager.broadcast.call_args[0][0])
+    # First call: agent_profiles broadcast (empty), second call: raw event
+    assert room.connection_manager.broadcast.call_count == 2
+    profiles_data = json.loads(room.connection_manager.broadcast.call_args_list[0][0][0])
+    assert profiles_data["type"] == "semantic:agent_profiles"
+    event_data = json.loads(room.connection_manager.broadcast.call_args_list[1][0][0])
     assert event_data["type"] == "on_chain_start"


### PR DESCRIPTION
## Summary

- 서버 모드에서 워크플로우 시작 시 에이전트 프로필 계층을 `agent_profiles` 이벤트로 브로드캐스트
- `_strip_llm()` 재귀 헬퍼로 중첩 에이전트의 LLM 설정(API 키 포함)을 안전하게 제거
- 클라이언트에서 `AgentProfilesReceived` 메시지로 `ParticipantPanel.initialize()` 호출

## Changes

| 파일 | 변경 |
|------|------|
| `doorae/server/room.py` | `_stream_engine_events`에서 프로필 브로드캐스트 + `_strip_llm()` 보안 헬퍼 |
| `doorae/interfaces/tui.py` | `AgentProfilesReceived` 메시지 + 핸들러 추가 |
| `doorae/interfaces/tui_ws_client.py` | `agent_profiles` 이벤트 디스패치 추가 |
| `tests/core/test_profile.py` | 재귀 프로필 직렬화 라운드트립 테스트 2건 |
| `tests/interfaces/test_tui_ws_client.py` | 이벤트 디스패치 테스트 1건 |
| `tests/server/test_streaming.py` | MockEngine에 setup_state 추가, 프로필 브로드캐스트 검증 |

## Measure Results

### 목적 달성도: 90% (before: 40%)
- 프로필 브로드캐스트: 5/5 (before: 1/5)
- LLM 설정 보안: 5/5 (before: 1/5) — 재귀적 `_strip_llm()`으로 중첩 API 키 제거
- 클라이언트 역직렬화: 4/5 (before: 2/5)
- 패널 초기화: 4/5 (before: 2/5)

### 구현 품질: 82% (before: 68%)
- 가독성: 4/5
- 관심사 분리: 4/5
- 에러 처리: 4/5
- 네이밍 명확성: 4/5
- 테스트 용이성: 5/5

## Security Note

`model_dump(exclude={"llm"})` 는 최상위 `llm` 필드만 제거하고 중첩 `agents[].llm` 은 남기는 문제가 있었음. `_strip_llm()` 재귀 헬퍼로 모든 레벨의 `llm` 키를 제거하여 API 키 노출 방지.

## Test plan

- [x] `uv run pytest tests/core/test_profile.py -x -v` — 프로필 라운드트립 테스트 통과
- [x] `uv run pytest tests/server/test_streaming.py -x -v` — 프로필 브로드캐스트 테스트 통과
- [x] `uv run pytest -x -v` — 전체 352 테스트 통과

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>