### PR TITLE
feat: render @mention highlights

### DIFF
--- a/doorae/interfaces/tui.py
+++ b/doorae/interfaces/tui.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import asyncio
 import colorsys
 import random
+import re
 import time
 from enum import Enum
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 from urllib.parse import quote, urlsplit, urlunsplit
 
 import httpx
@@ -52,6 +53,9 @@ def _random_speaker_color() -> str:
     l = random.uniform(0.45, 0.65)
     r, g, b = colorsys.hls_to_rgb(h, l, s)
     return f"#{int(r * 255):02x}{int(g * 255):02x}{int(b * 255):02x}"
+
+
+_MENTION_PATTERN = re.compile(r"(^|[^\w@.])(@[\w가-힣]+)")
 
 
 class SpinnerWidget(Widget):
@@ -152,6 +156,23 @@ class SpeechBubble(Widget):
         self._tool_indicator: SpinnerWidget | None = None
         self._header_spinner: SpinnerWidget | None = None
 
+    def _replace_mentions(self, text: str, formatter: Callable[[str], str]) -> str:
+        def repl(match: re.Match[str]) -> str:
+            prefix = match.group(1)
+            mention = match.group(2)
+            return f"{prefix}{formatter(mention)}"
+
+        return _MENTION_PATTERN.sub(repl, text)
+
+    def _highlight_mentions(self, text: str) -> str:
+        return self._replace_mentions(text, lambda mention: f"[bold #5eead4]{mention}[/]")
+
+    def _highlight_mentions_md(self, text: str) -> str:
+        def format_mention(mention: str) -> str:
+            return f"**{mention}**"
+
+        return self._replace_mentions(text, format_mention)
+
     def on_mount(self) -> None:
         if self.is_delegated:
             return
@@ -172,10 +193,11 @@ class SpeechBubble(Widget):
     def append_token(self, token: str) -> None:
         self._buffer += token
         if self._body is not None:
+            highlighted = self._highlight_mentions(escape(self._buffer))
             if self.is_delegated:
-                self._body.update(f"[dim]{escape(self._buffer)}[/dim]")
+                self._body.update(f"[dim]{highlighted}[/dim]")
             else:
-                self._body.update(self._buffer)
+                self._body.update(highlighted)
 
     def show_tool_started(self, tool_name: str) -> None:
         """tool 호출 시작 — spinner 인디케이터 표시."""
@@ -199,7 +221,7 @@ class SpeechBubble(Widget):
         if self._tool_indicator is not None:
             self._tool_indicator.remove()
             self._tool_indicator = None
-        self.mount(Markdown(self._buffer))
+        self.mount(Markdown(self._highlight_mentions_md(self._buffer)))
 
 
 class SubmittableTextArea(TextArea):

--- a/doorae/static/index.html
+++ b/doorae/static/index.html
@@ -195,6 +195,16 @@
             line-height: 1.4;
         }
 
+        .message .content .mention {
+            display: inline-block;
+            margin: 0 1px;
+            padding: 1px 6px;
+            border-radius: 6px;
+            background: #eef2ff;
+            color: #4f46e5;
+            font-weight: 600;
+        }
+
         .message .time {
             font-size: 0.75em;
             opacity: 0.7;
@@ -493,7 +503,10 @@
 
             const contentEl = currentMessageEl.querySelector('.content');
             if (contentEl) {
-                contentEl.textContent += data.content;
+                const previous = contentEl.dataset.rawContent || '';
+                const next = previous + data.content;
+                contentEl.dataset.rawContent = next;
+                contentEl.innerHTML = highlightMentions(next);
             }
             scrollMessagesToBottom();
         }
@@ -608,7 +621,8 @@
 
             const contentDiv = document.createElement('div');
             contentDiv.className = 'content';
-            contentDiv.textContent = content;
+            contentDiv.dataset.rawContent = content;
+            contentDiv.innerHTML = highlightMentions(content);
             messageDiv.appendChild(contentDiv);
 
             const timeDiv = document.createElement('div');
@@ -672,6 +686,15 @@
             const div = document.createElement('div');
             div.textContent = text;
             return div.innerHTML;
+        }
+
+        function highlightMentions(text) {
+            const escaped = escapeHtml(text);
+            const mentionPattern = /(^|[^0-9A-Za-z_가-힣@.])(@[0-9A-Za-z_가-힣]+)/g;
+            return escaped.replace(
+                mentionPattern,
+                (match, prefix, mention) => `${prefix}<span class="mention">${mention}</span>`
+            );
         }
 
         // Enter 키로 채팅 참여

--- a/tests/interfaces/test_tui.py
+++ b/tests/interfaces/test_tui.py
@@ -81,6 +81,36 @@ def _submitted_event(
     return SubmittableTextArea.Submitted(text_area=text_area, value=value)
 
 
+def test_speech_bubble_highlight_mentions_marks_mentions() -> None:
+    bubble = SpeechBubble(speaker="PM", color="#ffffff")
+
+    assert (
+        bubble._highlight_mentions("안건은 @PM 과 @TechLead 가 검토합니다")
+        == "안건은 [bold #5eead4]@PM[/] 과 [bold #5eead4]@TechLead[/] 가 검토합니다"
+    )
+
+
+def test_speech_bubble_highlight_mentions_keeps_plain_text() -> None:
+    bubble = SpeechBubble(speaker="PM", color="#ffffff")
+
+    assert bubble._highlight_mentions("멘션 없는 일반 텍스트") == "멘션 없는 일반 텍스트"
+
+
+def test_speech_bubble_highlight_mentions_skips_email_addresses() -> None:
+    bubble = SpeechBubble(speaker="PM", color="#ffffff")
+
+    assert bubble._highlight_mentions("문의는 user@example.com 으로 주세요") == "문의는 user@example.com 으로 주세요"
+
+
+def test_speech_bubble_highlight_mentions_md_wraps_mentions_in_bold() -> None:
+    bubble = SpeechBubble(speaker="PM", color="#ffffff")
+
+    assert (
+        bubble._highlight_mentions_md("@PM @TechLead 검토")
+        == "**@PM** **@TechLead** 검토"
+    )
+
+
 @pytest.mark.asyncio
 async def test_human_input_panel_hidden_by_default() -> None:
     app = DummyMeetingTuiApp(


### PR DESCRIPTION
Closes #269

## Summary
- highlight `@mention` tokens in TUI streaming bubbles with Rich styling
- render completed TUI messages with bolded mentions in Markdown
- add browser mention badge styling with safe HTML escaping and streaming re-rendering
- cover TUI mention highlighting with focused unit tests

## Testing
- `uv run pytest tests/interfaces/test_tui.py -x -v`
- `uv run --extra server pytest -x -v`