### PR TITLE
docs: add pre-alpha status badge and early development warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Doorae
 
+![Status](https://img.shields.io/badge/status-pre--alpha-orange)
+
 AI-powered team meeting system built on [LangGraph](https://github.com/langchain-ai/langgraph). Autonomous AI agents with distinct roles participate in structured meetings, discuss agendas, and produce actionable outcomes — all from your terminal.
+
+> [!WARNING]
+> Doorae is in early development and is not yet production-ready.
+> APIs, configuration, and meeting workflows may change without notice.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- README에 pre-alpha 상태 뱃지 추가
- 초기 개발 단계임을 알리는 WARNING 배너 추가

## Test plan
- [x] README.md 렌더링 확인 (뱃지 이미지, WARNING callout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)