### PR TITLE
feat: add project-aware run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,11 @@ This creates `.doorae/projects/demo/` with `project.yaml`, `config/agent_profile
 
 ### 4. Configure
 
-Edit `.env` with your API key, preferred model, and the project config paths you want to use:
+Edit `.env` with your API key and preferred models:
 
 ```env
 OPENAI_API_KEY=your-api-key-here
 OPENAI_BASE_URL=https://openrouter.ai/api/v1  # or https://api.openai.com/v1
-AGENT_PROFILES_PATH=.doorae/projects/demo/config/agent_profiles.yaml
-AGENDAS_PATH=.doorae/projects/demo/config/agendas.yaml
 
 LLM_MAIN_MODEL=deepseek/deepseek-v3.2
 LLM_TASK_MODEL=google/gemini-2.5-flash
@@ -100,13 +98,16 @@ LLM_TASK_MODEL=google/gemini-2.5-flash
 ### 5. Run
 
 ```bash
-uv run doorae
+uv run doorae run --project demo
 ```
 
 ## Usage
 
 ```bash
-# Default meeting
+# Project-aware meeting
+uv run doorae run --project demo
+
+# Default meeting (legacy env/config path flow)
 uv run doorae
 
 # Initialize a workspace and scaffold a project
@@ -119,8 +120,14 @@ uv run doorae -m "Emergency bug response meeting"
 # Classic CLI (no TUI)
 uv run doorae --classic
 
+# Project-aware classic CLI
+uv run doorae run --project demo --classic
+
 # Custom profiles & config
 uv run doorae --profiles config/custom_profiles.yaml --config .env.prod
+
+# Project-aware run with a custom .env
+uv run doorae run --project demo --config .env.prod
 
 # With LangSmith tracing
 uv run doorae --trace

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ LLM_TASK_MODEL=google/gemini-2.5-flash
 
 > [!TIP]
 > OpenRouter is recommended for cost efficiency. See `.env.example` for all configuration options including Azure OpenAI, local Ollama, and LangSmith tracing.
+> If you use `https://api.openai.com/v1`, switch to OpenAI model IDs such as `gpt-5-mini` and `gpt-5-nano`.
 
 ### 5. Run
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ uv run doorae project create demo
 
 This creates `.doorae/projects/demo/` with `project.yaml`, `config/agent_profiles.yaml`, `config/agendas.yaml`, and `config/mcp_servers.json`.
 
+The generated `config/agent_profiles.yaml` keeps an example per-agent `llm` override commented out. Uncomment it only when a specific project participant should use a different model/provider than the global `.env`.
+
 ### 4. Configure
 
 Edit `.env` with your API key and preferred models:
@@ -172,6 +174,7 @@ agents:
 
 > [!NOTE]
 > Per-agent `llm` fields support `${ENV_VAR}` syntax for environment variable substitution. Unset fields fall back to the global `.env` configuration.
+> The scaffolded PM profile keeps the override example commented out by default so first-run setup stays aligned with the global `.env` provider and model settings.
 
 ### Agendas (`config/agendas.yaml`)
 

--- a/config/agent_profiles.yaml
+++ b/config/agent_profiles.yaml
@@ -58,6 +58,14 @@ agents:
       # default_branch: "main"
       additional_instructions: |
         (IMPORTANT) 도구를 적극적으로 사용하세요.
+    # llm:
+    #   # Optional per-agent model/provider override.
+    #   # Uncomment when this project wants PM to use a dedicated model.
+    #   model: "qwen/qwen3.5-35b-a3b"
+    #   api_key: "${OPENAI_API_KEY}"
+    #   base_url: "${OPENAI_BASE_URL}"
+    #   temperature: 0.2
+    #   max_tokens: 3000
 
   - name: TechLead
     role: tech_lead

--- a/config/agent_profiles.yaml
+++ b/config/agent_profiles.yaml
@@ -58,13 +58,6 @@ agents:
       # default_branch: "main"
       additional_instructions: |
         (IMPORTANT) 도구를 적극적으로 사용하세요.
-    llm:
-      # 에이전트별 모델/provider 오버라이드 (미설정 항목은 .env 전역값 fallback)
-      model: "qwen/qwen3.5-35b-a3b"
-      api_key: "${OPENAI_API_KEY}"
-      base_url: "${OPENAI_BASE_URL}"
-      temperature: 0.2
-      max_tokens: 3000
 
   - name: TechLead
     role: tech_lead

--- a/doorae/interfaces/cli.py
+++ b/doorae/interfaces/cli.py
@@ -29,7 +29,13 @@ from doorae.core.server_address import (
 from doorae.interfaces.event_utils import random_speaker_color
 from doorae.interfaces.logging import setup_logging
 from doorae.interfaces.time_utils import format_elapsed
-from doorae.project import WorkspaceError, create_project, init_workspace
+from doorae.project import (
+    ProjectRunContext,
+    WorkspaceError,
+    create_project,
+    init_workspace,
+    resolve_project_run,
+)
 from doorae.server.models import RoomInfo
 
 if TYPE_CHECKING:
@@ -304,6 +310,50 @@ def _configure_runtime(
     return settings
 
 
+def _build_project_runtime_settings(
+    settings: Settings,
+    project_run: ProjectRunContext,
+) -> Settings:
+    """Override runtime config paths from a resolved workspace project."""
+    return settings.model_copy(
+        update={
+            "agent_profiles_path": str(project_run.profiles_path),
+            "agendas_path": str(project_run.agendas_path),
+        }
+    )
+
+
+def _run_project_command(
+    *,
+    project: str | None,
+    message: str,
+    classic: bool,
+    runtime_options: CliRuntimeOptions,
+    hide_delegated: bool,
+) -> None:
+    use_tui = should_use_tui(classic)
+    settings = _configure_runtime(runtime_options=runtime_options, use_tui=use_tui)
+
+    try:
+        project_run = resolve_project_run(Path.cwd(), project=project)
+        project_settings = _build_project_runtime_settings(settings, project_run)
+        asyncio.run(
+            run_meeting(
+                initial_message=message,
+                profiles_path=project_run.profiles_path,
+                settings=project_settings,
+                use_tui=use_tui,
+                hide_delegated=hide_delegated,
+            )
+        )
+    except WorkspaceError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1) from exc
+    except RuntimeError as exc:
+        console.print(f"[bold red]?ㅻ쪟:[/bold red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+
 def _run_server_command(
     *,
     initial_message: str,
@@ -436,6 +486,71 @@ def main(
         classic=classic,
         runtime_options=runtime_options,
         version=version,
+        hide_delegated=hide_delegated,
+    )
+
+@app.command("run")
+def run_command(
+    project: Optional[str] = typer.Option(
+        None,
+        "--project",
+        help="Workspace project slug or project path to run",
+    ),
+    message: str = typer.Option(
+        DEFAULT_MESSAGE,
+        "--message",
+        "-m",
+        help="Meeting start message",
+    ),
+    classic: bool = typer.Option(
+        False,
+        "--classic",
+        help="Use classic CLI output instead of TUI",
+    ),
+    config: Optional[Path] = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to a custom .env file",
+        exists=True,
+        dir_okay=False,
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Enable verbose logging",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Reduce logging output",
+    ),
+    trace: Optional[bool] = typer.Option(
+        None,
+        "--trace",
+        "-t",
+        help="Enable LangSmith tracing",
+    ),
+    hide_delegated: bool = typer.Option(
+        False,
+        "--hide-delegated",
+        help="Hide delegated sub-agent output in classic CLI mode",
+    ),
+) -> None:
+    """Run a meeting using the current or selected workspace project."""
+    runtime_options = CliRuntimeOptions(
+        config=config,
+        verbose=verbose,
+        quiet=quiet,
+        trace=trace,
+    )
+    _run_project_command(
+        project=project,
+        message=message,
+        classic=classic,
+        runtime_options=runtime_options,
         hide_delegated=hide_delegated,
     )
 

--- a/doorae/project/__init__.py
+++ b/doorae/project/__init__.py
@@ -4,23 +4,32 @@ from doorae.project.models import (
     ProjectConfig,
     ProjectCreateResult,
     ProjectPaths,
+    ProjectRunContext,
     WorkspaceConfig,
     WorkspaceInitResult,
     WorkspacePaths,
 )
 from doorae.project.service import (
+    CurrentProjectNotSetError,
     ProjectExistsError,
+    ProjectConfigError,
+    ProjectNotFoundError,
     WorkspaceError,
     WorkspaceNotFoundError,
     create_project,
     init_workspace,
+    resolve_project_run,
 )
 
 __all__ = [
+    "CurrentProjectNotSetError",
     "ProjectConfig",
+    "ProjectConfigError",
     "ProjectCreateResult",
     "ProjectExistsError",
     "ProjectPaths",
+    "ProjectNotFoundError",
+    "ProjectRunContext",
     "WorkspaceConfig",
     "WorkspaceError",
     "WorkspaceInitResult",
@@ -28,4 +37,5 @@ __all__ = [
     "WorkspacePaths",
     "create_project",
     "init_workspace",
+    "resolve_project_run",
 ]

--- a/doorae/project/models.py
+++ b/doorae/project/models.py
@@ -89,6 +89,41 @@ class ProjectConfig:
             "mcp_servers_path": self.mcp_servers_path,
         }
 
+    @classmethod
+    def from_dict(cls, raw: object) -> "ProjectConfig":
+        """Parse project metadata loaded from YAML."""
+        if not isinstance(raw, dict):
+            raise TypeError("Project metadata must be a mapping.")
+
+        name = raw.get("name")
+        slug = raw.get("slug")
+        version = raw.get("version", cls.version)
+        agent_profiles_path = raw.get("agent_profiles_path", cls.agent_profiles_path)
+        agendas_path = raw.get("agendas_path", cls.agendas_path)
+        mcp_servers_path = raw.get("mcp_servers_path", cls.mcp_servers_path)
+
+        required_values = {
+            "name": name,
+            "slug": slug,
+            "agent_profiles_path": agent_profiles_path,
+            "agendas_path": agendas_path,
+            "mcp_servers_path": mcp_servers_path,
+        }
+        normalized_values: dict[str, str] = {}
+        for field_name, value in required_values.items():
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"Project metadata field '{field_name}' must be a non-empty string.")
+            normalized_values[field_name] = value.strip()
+
+        return cls(
+            name=normalized_values["name"],
+            slug=normalized_values["slug"],
+            version=int(version),
+            agent_profiles_path=normalized_values["agent_profiles_path"],
+            agendas_path=normalized_values["agendas_path"],
+            mcp_servers_path=normalized_values["mcp_servers_path"],
+        )
+
 
 @dataclass(frozen=True)
 class WorkspaceInitResult:
@@ -105,3 +140,15 @@ class ProjectCreateResult:
 
     paths: ProjectPaths
     config: ProjectConfig
+
+
+@dataclass(frozen=True)
+class ProjectRunContext:
+    """Resolved project metadata and config paths for `doorae run`."""
+
+    workspace: WorkspaceConfig
+    project: ProjectConfig
+    project_dir: Path
+    project_file: Path
+    profiles_path: Path
+    agendas_path: Path

--- a/doorae/project/service.py
+++ b/doorae/project/service.py
@@ -13,6 +13,7 @@ from doorae.project.models import (
     ProjectConfig,
     ProjectCreateResult,
     ProjectPaths,
+    ProjectRunContext,
     WorkspaceConfig,
     WorkspaceInitResult,
     WorkspacePaths,
@@ -49,6 +50,18 @@ class InvalidProjectNameError(WorkspaceError):
 
 class ProjectExistsError(WorkspaceError):
     """Raised when a scaffold with the target slug already exists."""
+
+
+class CurrentProjectNotSetError(WorkspaceError):
+    """Raised when a workspace has no current project configured."""
+
+
+class ProjectNotFoundError(WorkspaceError):
+    """Raised when the requested project slug or path cannot be resolved."""
+
+
+class ProjectConfigError(WorkspaceError):
+    """Raised when project metadata or referenced config paths are invalid."""
 
 
 def resolve_workspace_paths(base_dir: Path) -> WorkspacePaths:
@@ -156,6 +169,47 @@ def create_project(base_dir: Path, name: str) -> ProjectCreateResult:
     return ProjectCreateResult(paths=project_paths, config=project_config)
 
 
+def resolve_project_run(
+    base_dir: Path,
+    *,
+    project: str | None = None,
+) -> ProjectRunContext:
+    """Resolve the project metadata and config files for `doorae run`."""
+    workspace_paths = resolve_workspace_paths(base_dir)
+    workspace_config = _load_workspace_config(workspace_paths)
+
+    selector = (project or workspace_config.current_project or "").strip()
+    if not selector:
+        raise CurrentProjectNotSetError(
+            f"No current project is set in {workspace_paths.workspace_file}. "
+            "Use 'doorae run --project <slug|path>' or update current_project."
+        )
+
+    project_dir, project_file = _resolve_project_reference(
+        workspace_paths,
+        workspace_config,
+        selector,
+    )
+    project_config = _load_project_config(project_file)
+
+    return ProjectRunContext(
+        workspace=workspace_config,
+        project=project_config,
+        project_dir=project_dir,
+        project_file=project_file,
+        profiles_path=_resolve_project_config_path(
+            project_dir,
+            project_config.agent_profiles_path,
+            field_name="agent_profiles_path",
+        ),
+        agendas_path=_resolve_project_config_path(
+            project_dir,
+            project_config.agendas_path,
+            field_name="agendas_path",
+        ),
+    )
+
+
 def _read_template_text(relative_path: Path) -> str:
     """Read a packaged scaffold template as UTF-8 text."""
     try:
@@ -196,6 +250,82 @@ def _load_workspace_config(paths: WorkspacePaths) -> WorkspaceConfig:
         raise WorkspaceError(
             f"Workspace metadata at {paths.workspace_file} is invalid."
         ) from exc
+
+
+def _resolve_project_reference(
+    workspace_paths: WorkspacePaths,
+    workspace_config: WorkspaceConfig,
+    selector: str,
+) -> tuple[Path, Path]:
+    """Resolve a slug or path selector to a concrete project directory and file."""
+    if _looks_like_path(selector):
+        candidate = Path(selector).expanduser()
+        if not candidate.is_absolute():
+            candidate = workspace_paths.root_dir / candidate
+        candidate = candidate.resolve()
+        project_file = candidate if candidate.name == "project.yaml" else candidate / "project.yaml"
+        if not project_file.exists():
+            raise ProjectNotFoundError(
+                f"Project path '{selector}' does not contain a project.yaml file: {project_file}"
+            )
+        return project_file.parent, project_file
+
+    project_paths = _resolve_project_paths(workspace_paths, workspace_config, selector)
+    if not project_paths.project_file.exists():
+        raise ProjectNotFoundError(
+            f"Project '{selector}' was not found at {project_paths.project_dir}."
+        )
+    return project_paths.project_dir, project_paths.project_file
+
+
+def _load_project_config(project_file: Path) -> ProjectConfig:
+    """Load and validate project metadata from disk."""
+    try:
+        raw_config = yaml.safe_load(project_file.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ProjectConfigError(
+            f"Project metadata at {project_file} is not valid YAML."
+        ) from exc
+
+    try:
+        return ProjectConfig.from_dict(raw_config)
+    except (TypeError, ValueError) as exc:
+        raise ProjectConfigError(
+            f"Project metadata at {project_file} is invalid."
+        ) from exc
+
+
+def _resolve_project_config_path(
+    project_dir: Path,
+    raw_path: str,
+    *,
+    field_name: str,
+) -> Path:
+    """Resolve a project-local config file reference and ensure it exists."""
+    config_path = Path(raw_path).expanduser()
+    if not config_path.is_absolute():
+        config_path = project_dir / config_path
+    config_path = config_path.resolve()
+
+    if not config_path.exists():
+        raise ProjectConfigError(
+            f"Project config '{field_name}' was not found: {config_path}"
+        )
+    if not config_path.is_file():
+        raise ProjectConfigError(
+            f"Project config '{field_name}' must point to a file: {config_path}"
+        )
+    return config_path
+
+
+def _looks_like_path(selector: str) -> bool:
+    """Return whether a project selector should be interpreted as a filesystem path."""
+    candidate = Path(selector)
+    if candidate.is_absolute():
+        return True
+    if len(candidate.parts) > 1:
+        return True
+    return selector.startswith((".", "~"))
 
 
 def _resolve_project_paths(

--- a/doorae/templates/default/config/agent_profiles.yaml
+++ b/doorae/templates/default/config/agent_profiles.yaml
@@ -58,6 +58,14 @@ agents:
       # default_branch: "main"
       additional_instructions: |
         (IMPORTANT) 도구를 적극적으로 사용하세요.
+    # llm:
+    #   # Optional per-agent model/provider override.
+    #   # Uncomment when this project wants PM to use a dedicated model.
+    #   model: "qwen/qwen3.5-35b-a3b"
+    #   api_key: "${OPENAI_API_KEY}"
+    #   base_url: "${OPENAI_BASE_URL}"
+    #   temperature: 0.2
+    #   max_tokens: 3000
 
   - name: TechLead
     role: tech_lead

--- a/doorae/templates/default/config/agent_profiles.yaml
+++ b/doorae/templates/default/config/agent_profiles.yaml
@@ -58,13 +58,6 @@ agents:
       # default_branch: "main"
       additional_instructions: |
         (IMPORTANT) 도구를 적극적으로 사용하세요.
-    llm:
-      # 에이전트별 모델/provider 오버라이드 (미설정 항목은 .env 전역값 fallback)
-      model: "qwen/qwen3.5-35b-a3b"
-      api_key: "${OPENAI_API_KEY}"
-      base_url: "${OPENAI_BASE_URL}"
-      temperature: 0.2
-      max_tokens: 3000
 
   - name: TechLead
     role: tech_lead

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -24,7 +24,7 @@ from doorae.interfaces.cli import (
     run_meeting,
     run_server_meeting,
 )
-from doorae.project import WorkspaceError, init_workspace
+from doorae.project import WorkspaceError, create_project, init_workspace
 
 
 runner = CliRunner()
@@ -68,6 +68,7 @@ def test_cli_help() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "Doorae" in result.stdout
+    assert "run" in result.stdout
     assert "create" in result.stdout
     assert "join" in result.stdout
     assert "rooms" in result.stdout
@@ -300,6 +301,16 @@ def test_project_create_command_is_visible_in_help() -> None:
     assert "NAME" in result.stdout
 
 
+def test_run_command_is_visible_in_help() -> None:
+    result = runner.invoke(app, ["run", "--help"])
+    assert result.exit_code == 0
+    assert "--project" in result.stdout
+    assert "--message" in result.stdout
+    assert "--classic" in result.stdout
+    assert "--trace" in result.stdout
+    assert "--hide-delegated" in result.stdout
+
+
 def test_serve_command_is_visible_in_help() -> None:
     result = runner.invoke(app, ["serve", "--help"])
     assert result.exit_code == 0
@@ -476,6 +487,99 @@ def test_module_project_create_command_creates_scaffold() -> None:
             / "config"
             / "mcp_servers.json"
         ).exists()
+    finally:
+        remove_workspace_dir(workspace)
+
+
+def test_run_command_uses_current_project_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = create_workspace_dir("run-current-project")
+    captured: dict[str, object] = {}
+
+    async def stub_run_meeting(
+        initial_message: str,
+        profiles_path: Path | None = None,
+        settings: Settings | None = None,
+        use_tui: bool = False,
+        hide_delegated: bool = False,
+    ) -> None:
+        captured["initial_message"] = initial_message
+        captured["profiles_path"] = profiles_path
+        captured["settings"] = settings
+        captured["use_tui"] = use_tui
+        captured["hide_delegated"] = hide_delegated
+
+    monkeypatch.setattr("doorae.interfaces.cli.run_meeting", stub_run_meeting)
+    monkeypatch.setattr(
+        "doorae.interfaces.cli._configure_runtime",
+        lambda runtime_options, use_tui: Settings(),
+    )
+
+    try:
+        init_workspace(workspace)
+        create_project(workspace, "Weekly Dev")
+        (workspace / ".doorae" / "workspace.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "version": 1,
+                    "current_project": "weekly-dev",
+                    "projects_dir": ".doorae/projects",
+                },
+                allow_unicode=True,
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        original_cwd = Path.cwd()
+        os.chdir(workspace)
+        try:
+            result = runner.invoke(
+                app,
+                ["run", "--message", "Project sync", "--classic", "--hide-delegated"],
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        assert result.exit_code == 0
+        assert captured["initial_message"] == "Project sync"
+        assert captured["profiles_path"] == (
+            workspace / ".doorae" / "projects" / "weekly-dev" / "config" / "agent_profiles.yaml"
+        )
+        settings = captured["settings"]
+        assert isinstance(settings, Settings)
+        assert settings.agent_profiles_path == str(captured["profiles_path"])
+        assert settings.agendas_path == str(
+            workspace / ".doorae" / "projects" / "weekly-dev" / "config" / "agendas.yaml"
+        )
+        assert captured["use_tui"] is False
+        assert captured["hide_delegated"] is True
+    finally:
+        remove_workspace_dir(workspace)
+
+
+def test_run_command_fails_when_current_project_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace = create_workspace_dir("run-no-current-project")
+    monkeypatch.setattr(
+        "doorae.interfaces.cli._configure_runtime",
+        lambda runtime_options, use_tui: Settings(),
+    )
+
+    try:
+        init_workspace(workspace)
+
+        original_cwd = Path.cwd()
+        os.chdir(workspace)
+        try:
+            result = runner.invoke(app, ["run"])
+        finally:
+            os.chdir(original_cwd)
+
+        assert result.exit_code == 1
+        assert "current_project" in result.stderr
     finally:
         remove_workspace_dir(workspace)
 

--- a/tests/test_project_setup.py
+++ b/tests/test_project_setup.py
@@ -48,10 +48,13 @@ def test_packaged_templates_are_available() -> None:
 
 
 def test_default_profiles_template_uses_global_llm_settings_by_default() -> None:
-    profiles = yaml.safe_load(read_packaged_template("config/agent_profiles.yaml"))
+    template_text = read_packaged_template("config/agent_profiles.yaml")
+    profiles = yaml.safe_load(template_text)
     pm_agent = next(agent for agent in profiles["agents"] if agent["name"] == "PM")
 
     assert "llm" not in pm_agent
+    assert "# llm:" in template_text
+    assert '#   model: "qwen/qwen3.5-35b-a3b"' in template_text
 
 
 def test_create_project_scaffold_creates_expected_files() -> None:

--- a/tests/test_project_setup.py
+++ b/tests/test_project_setup.py
@@ -11,10 +11,14 @@ import yaml
 
 from doorae import PROJECT_ROOT
 from doorae.project import (
+    CurrentProjectNotSetError,
     ProjectExistsError,
+    ProjectConfigError,
+    ProjectNotFoundError,
     WorkspaceNotFoundError,
     create_project,
     init_workspace,
+    resolve_project_run,
 )
 
 
@@ -113,5 +117,105 @@ def test_create_project_rejects_duplicate_slug() -> None:
 
         with pytest.raises(ProjectExistsError, match="weekly-dev"):
             create_project(workspace, "weekly_dev")
+    finally:
+        remove_workspace_dir(workspace)
+
+
+def test_resolve_project_run_uses_current_project_from_workspace() -> None:
+    workspace = create_workspace_dir("resolve-current-project")
+    try:
+        init_workspace(workspace)
+        create_result = create_project(workspace, "Weekly Dev")
+
+        workspace_file = workspace / ".doorae" / "workspace.yaml"
+        workspace_file.write_text(
+            yaml.safe_dump(
+                {
+                    "version": 1,
+                    "current_project": "weekly-dev",
+                    "projects_dir": ".doorae/projects",
+                },
+                allow_unicode=True,
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        run_context = resolve_project_run(workspace)
+
+        assert run_context.project.slug == "weekly-dev"
+        assert run_context.project_dir == create_result.paths.project_dir
+        assert run_context.project_file == create_result.paths.project_file
+        assert run_context.profiles_path == create_result.paths.profiles_file
+        assert run_context.agendas_path == create_result.paths.agendas_file
+    finally:
+        remove_workspace_dir(workspace)
+
+
+def test_resolve_project_run_accepts_relative_project_path() -> None:
+    workspace = create_workspace_dir("resolve-project-path")
+    try:
+        init_workspace(workspace)
+        create_result = create_project(workspace, "Weekly Dev")
+
+        run_context = resolve_project_run(
+            workspace,
+            project=".doorae/projects/weekly-dev",
+        )
+
+        assert run_context.project.slug == "weekly-dev"
+        assert run_context.project_dir == create_result.paths.project_dir
+        assert run_context.profiles_path == create_result.paths.profiles_file
+        assert run_context.agendas_path == create_result.paths.agendas_file
+    finally:
+        remove_workspace_dir(workspace)
+
+
+def test_resolve_project_run_requires_current_project_when_selector_missing() -> None:
+    workspace = create_workspace_dir("resolve-no-current-project")
+    try:
+        init_workspace(workspace)
+        create_project(workspace, "Weekly Dev")
+
+        with pytest.raises(CurrentProjectNotSetError, match="current_project"):
+            resolve_project_run(workspace)
+    finally:
+        remove_workspace_dir(workspace)
+
+
+def test_resolve_project_run_rejects_unknown_project_slug() -> None:
+    workspace = create_workspace_dir("resolve-missing-project")
+    try:
+        init_workspace(workspace)
+
+        with pytest.raises(ProjectNotFoundError, match="missing-project"):
+            resolve_project_run(workspace, project="missing-project")
+    finally:
+        remove_workspace_dir(workspace)
+
+
+def test_resolve_project_run_rejects_invalid_project_config_paths() -> None:
+    workspace = create_workspace_dir("resolve-invalid-project-config")
+    try:
+        init_workspace(workspace)
+        create_result = create_project(workspace, "Weekly Dev")
+        create_result.paths.project_file.write_text(
+            yaml.safe_dump(
+                {
+                    "version": 1,
+                    "name": "Weekly Dev",
+                    "slug": "weekly-dev",
+                    "agent_profiles_path": "config/missing-profiles.yaml",
+                    "agendas_path": "config/agendas.yaml",
+                    "mcp_servers_path": "config/mcp_servers.json",
+                },
+                allow_unicode=True,
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ProjectConfigError, match="agent_profiles_path"):
+            resolve_project_run(workspace, project="weekly-dev")
     finally:
         remove_workspace_dir(workspace)

--- a/tests/test_project_setup.py
+++ b/tests/test_project_setup.py
@@ -47,6 +47,13 @@ def test_packaged_templates_are_available() -> None:
     assert '"mcpServers"' in read_packaged_template("config/mcp_servers.json")
 
 
+def test_default_profiles_template_uses_global_llm_settings_by_default() -> None:
+    profiles = yaml.safe_load(read_packaged_template("config/agent_profiles.yaml"))
+    pm_agent = next(agent for agent in profiles["agents"] if agent["name"] == "PM")
+
+    assert "llm" not in pm_agent
+
+
 def test_create_project_scaffold_creates_expected_files() -> None:
     workspace = create_workspace_dir("scaffold")
     try:
@@ -87,6 +94,9 @@ def test_create_project_scaffold_creates_expected_files() -> None:
         assert result.paths.profiles_file.read_text(
             encoding="utf-8"
         ) == read_packaged_template("config/agent_profiles.yaml")
+        scaffold_profiles = yaml.safe_load(result.paths.profiles_file.read_text(encoding="utf-8"))
+        scaffold_pm = next(agent for agent in scaffold_profiles["agents"] if agent["name"] == "PM")
+        assert "llm" not in scaffold_pm
         assert result.paths.agendas_file.read_text(encoding="utf-8") == read_packaged_template(
             "config/agendas.yaml"
         )


### PR DESCRIPTION
Closes #207

## Summary
- add a project-aware doorae run command that resolves workspace current_project or an explicit --project selector
- validate project metadata and inject resolved agenda/profile paths into the existing meeting runtime
- document the new workflow in README and cover it with project service and CLI tests

## Testing
- I:\doorae\.venv\Scripts\python.exe -m py_compile doorae\interfaces\cli.py doorae\project\service.py doorae\project\models.py doorae\project\__init__.py
- I:\doorae\.venv\Scripts\python.exe -m doorae --help
- I:\doorae\.venv\Scripts\python.exe -m doorae run --help
- I:\doorae\.venv\Scripts\doorae.exe --help
- I:\doorae\.venv\Scripts\python.exe -m pytest -q --basetemp=.tmp\pytest-full2 -p no:cacheprovider