### PR TITLE
fix: strip think tags and reset speaker counts on agenda transition (#278, #281)

### DIFF
--- a/doorae/agents/base_agent.py
+++ b/doorae/agents/base_agent.py
@@ -10,6 +10,7 @@ from loguru import logger
 from doorae.config import create_main_llm
 from doorae.core.date_context import format_today_context
 from doorae.core.profile import AgentProfile
+from doorae.core.text_utils import strip_thinking_tags
 
 
 class BaseAgent:
@@ -47,6 +48,13 @@ Respond according to your role and the given task.
             prompt += f"\n\n{self.profile.metadata['additional_instructions']}"
         
         return prompt
+
+    @staticmethod
+    def _sanitize_response_content(response: AIMessage) -> AIMessage:
+        content = getattr(response, "content", "")
+        if isinstance(content, str):
+            response.content = strip_thinking_tags(content)
+        return response
 
     def _build_user_prompt(self, context: Dict[str, Any]) -> str:
         """사용자 프롬프트 생성"""
@@ -115,6 +123,8 @@ Always base your contributions on real data when tools are available.
         if not active_tools:
             # 도구 없으면 단순 호출
             response = await self._llm.ainvoke(messages, config=config)
+            if isinstance(response, AIMessage):
+                response = self._sanitize_response_content(response)
             return response
 
         # Tool-calling 루프
@@ -144,6 +154,7 @@ Always base your contributions on real data when tools are available.
             tool_messages.append(response)
 
             if not response.tool_calls:
+                response = self._sanitize_response_content(response)
                 logger.info(f"[{self.name}] ✅ 최종 응답 생성 완료 (총 {iteration}번 반복)")
                 return response
 
@@ -204,7 +215,8 @@ Always base your contributions on real data when tools are available.
                 ("human", self._build_user_prompt(context))
             ])
             chain = prompt | self._llm | StrOutputParser()
-            return await chain.ainvoke({})
+            response = await chain.ainvoke({})
+            return strip_thinking_tags(response)
 
         # invoke_with_tools 사용
         user_prompt = self._build_user_prompt(context)

--- a/doorae/core/text_utils.py
+++ b/doorae/core/text_utils.py
@@ -1,0 +1,18 @@
+"""Text sanitization helpers for model outputs."""
+
+from __future__ import annotations
+
+import re
+
+_THINK_BLOCK_RE = re.compile(r"<think>[\s\S]*?</think>", re.DOTALL)
+_THINK_TAG_RE = re.compile(r"</?think>")
+
+
+def strip_thinking_tags(content: str | None) -> str:
+    """Remove Qwen-style thinking tags from model output."""
+    if not content:
+        return ""
+
+    cleaned = _THINK_BLOCK_RE.sub("", content)
+    cleaned = _THINK_TAG_RE.sub("", cleaned)
+    return cleaned.strip()

--- a/doorae/graph/nodes/agent.py
+++ b/doorae/graph/nodes/agent.py
@@ -12,6 +12,7 @@ from loguru import logger
 from doorae.agents.base_agent import BaseAgent
 from doorae.core.date_context import format_today_context
 from doorae.core.profile import AgentProfile
+from doorae.core.text_utils import strip_thinking_tags
 from doorae.graph.agenda_tools import (
     create_approve_tool,
     create_propose_tool,
@@ -234,7 +235,8 @@ class AgentNodeExecutor:
         )
         response.name = self.profile.name
 
-        content = getattr(response, "content", "") or ""
+        content = strip_thinking_tags(getattr(response, "content", "") or "")
+        response.content = content
         if not content.strip():
             response = AIMessage(
                 content=f"({self.profile.name}: 현재 추가 의견이 없습니다.)",

--- a/doorae/graph/nodes/process.py
+++ b/doorae/graph/nodes/process.py
@@ -283,6 +283,7 @@ class ProcessResponseNode(BaseNode):
                 if decision:
                     new_agendas[current_idx]["decision"] = decision
                 new_idx = current_idx + 1
+                new_counts = {speaker_name: 1}
                 # 다음 안건 시작 시간 설정
                 if new_idx < len(new_agendas):
                     new_agendas[new_idx]["status"] = "in_progress"

--- a/tests/agents/test_base_agent.py
+++ b/tests/agents/test_base_agent.py
@@ -145,3 +145,51 @@ async def test_invoke_with_tools_unknown_tool_returns_error_message(agent_profil
     assert tool_messages[0].tool_call_id == "call-1"
     assert "missing_tool" in tool_messages[0].content
     assert "existing_tool" in tool_messages[0].content
+
+
+@pytest.mark.asyncio
+async def test_invoke_with_tools_strips_thinking_tags_without_tools(agent_profile):
+    mock_llm = AsyncMock()
+    mock_llm.ainvoke = AsyncMock(
+        return_value=AIMessage(content="<think>reasoning</think>actual response")
+    )
+
+    agent = BaseAgent(
+        name="TestAgent",
+        profile=agent_profile,
+        llm=mock_llm,
+    )
+
+    response = await agent.invoke_with_tools([HumanMessage(content="Respond")])
+
+    assert response.content == "actual response"
+
+
+@pytest.mark.asyncio
+async def test_invoke_with_tools_strips_thinking_tags_after_tool_loop(agent_profile):
+    bound_llm = AsyncMock()
+    bound_llm.ainvoke = AsyncMock(
+        return_value=AIMessage(content="<think>reasoning</think>")
+    )
+
+    mock_llm = MagicMock()
+    mock_llm.bind_tools.return_value = bound_llm
+
+    agent = BaseAgent(
+        name="TestAgent",
+        profile=agent_profile,
+        llm=mock_llm,
+    )
+
+    class DummyTool:
+        name = "existing_tool"
+
+        async def ainvoke(self, _args):
+            return "unused"
+
+    response = await agent.invoke_with_tools(
+        [HumanMessage(content="Respond")],
+        extra_tools=[DummyTool()],
+    )
+
+    assert response.content == ""

--- a/tests/core/test_text_utils.py
+++ b/tests/core/test_text_utils.py
@@ -1,0 +1,34 @@
+"""Tests for text sanitization helpers."""
+
+from doorae.core.text_utils import strip_thinking_tags
+
+
+def test_strip_empty_string():
+    assert strip_thinking_tags("") == ""
+
+
+def test_strip_none_returns_empty_string():
+    assert strip_thinking_tags(None) == ""
+
+
+def test_strip_no_tags():
+    assert strip_thinking_tags("hello") == "hello"
+
+
+def test_strip_think_block():
+    assert strip_thinking_tags("<think>reasoning</think>real") == "real"
+
+
+def test_strip_think_only():
+    assert strip_thinking_tags("<think>reasoning</think>") == ""
+
+
+def test_strip_closing_tag_only():
+    assert strip_thinking_tags("</think>\ncontent") == "content"
+
+
+def test_strip_multiline_think():
+    assert (
+        strip_thinking_tags("<think>\nline1\nline2\n</think>\nok")
+        == "ok"
+    )

--- a/tests/graph/nodes/test_process.py
+++ b/tests/graph/nodes/test_process.py
@@ -317,6 +317,30 @@ class TestProcessResponseNode:
         model.bind.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_execute_resets_speaker_counts_on_agenda_transition(self):
+        node = ProcessResponseNode(model=MagicMock(), valid_speakers=["Host", "PM", "TechLead"])
+        node._extract_decision = AsyncMock(return_value="안건 정리")
+        state = {
+            "messages": [AIMessage(content="다음 안건으로 넘어가겠습니다.", name="Host")],
+            "agendas": [
+                {"title": "안건1", "status": "in_progress", "required_speakers": ["Host", "PM", "TechLead"]},
+                {"title": "안건2", "status": "pending", "required_speakers": ["Host", "PM"]},
+            ],
+            "current_agenda_idx": 0,
+            "pending_speakers": ["Host"],
+            "speaker_counts": {"Host": 3, "PM": 2, "TechLead": 1},
+            "turn_count": 4,
+            "current_agenda_start_turn": 0,
+        }
+
+        result = await node.execute(state)
+
+        assert result["current_agenda_idx"] == 1
+        assert result["speaker_counts"] == {"Host": 1}
+        assert result["agendas"][0]["status"] == "completed"
+        assert result["agendas"][1]["status"] == "in_progress"
+
+    @pytest.mark.asyncio
     async def test_extract_decision_returns_summary(self, monkeypatch):
         """LLM이 정상 응답하면 decision 문자열을 반환."""
         response_model = MagicMock()

--- a/tests/graph/nodes/test_refill.py
+++ b/tests/graph/nodes/test_refill.py
@@ -198,3 +198,28 @@ class TestRefillSpeakersNode:
         result = await node.execute(state)
 
         assert result["pending_speakers"] == ["Alice"]
+
+    @pytest.mark.asyncio
+    async def test_refill_reschedules_required_speakers_after_agenda_transition(self, node):
+        state = MeetingState(
+            messages=[],
+            pending_speakers=[],
+            agendas=[
+                {
+                    "title": "안건1",
+                    "status": "completed",
+                    "required_speakers": ["Host", "PM", "TechLead"],
+                },
+                {
+                    "title": "안건2",
+                    "status": "in_progress",
+                    "required_speakers": ["Host", "PM"],
+                },
+            ],
+            current_agenda_idx=1,
+            speaker_counts={"Host": 1},
+        )
+
+        result = await node.execute(state)
+
+        assert result["pending_speakers"] == ["PM"]

--- a/tests/graph/nodes/test_summarize.py
+++ b/tests/graph/nodes/test_summarize.py
@@ -198,6 +198,42 @@ class TestInlineSummarization:
             call_kwargs = mock_summarize.call_args
             assert call_kwargs[1]["running_summary"] is prev_summary
 
+    @pytest.mark.asyncio
+    async def test_execute_uses_placeholder_when_thinking_tags_strip_to_empty(self):
+        profile = _make_profile()
+        mock_model = MagicMock()
+        mock_agent = AsyncMock()
+        mock_agent.invoke_with_tools = AsyncMock(
+            return_value=AIMessage(content="<think>internal reasoning</think>", name="TestAgent")
+        )
+
+        mock_sum_result = SummarizationResult(
+            messages=[HumanMessage(content="msg")],
+            running_summary=None,
+        )
+
+        with patch(
+            "doorae.graph.nodes.agent.summarize_messages",
+            return_value=mock_sum_result,
+        ):
+            executor = AgentNodeExecutor(
+                profile=profile, model=mock_model
+            )
+            executor.agent = mock_agent
+            executor._summary_model = MagicMock()
+
+            state = MeetingState(
+                messages=[HumanMessage(content="test")],
+                agendas=[],
+                summary=None,
+                pending_proposals=[],
+                participant_statuses={},
+            )
+
+            result = await executor.execute(state)
+
+            assert result["messages"][0].content == "(TestAgent: 현재 추가 의견이 없습니다.)"
+
     def test_get_summary_model_lazy_creation(self):
         """_get_summary_model이 lazy하게 생성되는지 확인"""
         profile = _make_profile()


### PR DESCRIPTION
## Summary
- **#278**: LLM 응답에 포함되는 `<think>...</think>` 추론 블록을 사용자에게 노출하지 않도록 `strip_thinking_tags()` 유틸리티 추가. `BaseAgent`, `AgentNode`, `SummarizeNode` 등 모든 응답 경로에서 sanitize 처리
- **#281**: `ProcessResponseNode`에서 안건 전환 시 `speaker_counts`를 리셋하지 않아 발언 순서가 꼬이는 버그 수정

## Changes
- `doorae/core/text_utils.py` — `strip_thinking_tags()` 유틸리티 신규
- `doorae/agents/base_agent.py` — 응답 경로에 think 태그 제거 적용
- `doorae/graph/nodes/agent.py` — AgentNode 응답 sanitize
- `doorae/graph/nodes/process.py` — 안건 전환 시 speaker_counts 리셋

## Test plan
- [x] `test_text_utils.py` — strip_thinking_tags 단위 테스트
- [x] `test_base_agent.py` — think 태그 제거 통합 테스트
- [x] `test_process.py` — 안건 전환 시 카운트 리셋 검증
- [x] `test_refill.py` — 안건 전환 후 required_speakers 재스케줄 검증
- [x] `test_summarize.py` — think 태그만 있는 응답 시 placeholder 처리 검증

Closes #278, Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)