### PR TITLE
Add roadmap docs with neutral external references

### DIFF
--- a/docs/roadmap/agent-daemon-bridge.md
+++ b/docs/roadmap/agent-daemon-bridge.md
@@ -1,0 +1,189 @@
+# Agent Daemon Bridge
+
+!!! warning "계획된 기능 (미구현)"
+    이 문서는 향후 구현 예정인 기능을 설명합니다. 현재 사용할 수 없습니다.
+
+## 개요
+
+Agent Daemon Bridge는 Doorae 서버와 로컬 AI agent runtime을 연결하는 **상주 데몬 프로세스**입니다.
+기존 로컬 agent daemon 패턴과 유사한 개념이지만,
+Doorae는 **오픈소스 runtime**을 대상으로 합니다.
+
+- [OpenHands](https://github.com/All-Hands-AI/OpenHands) (구 OpenDevin)
+- [Claude Agent SDK](https://docs.anthropic.com/en/docs/agents-sdk)
+- 기타 LangChain 호환 agent runtime
+
+데몬은 백그라운드에서 실행되며, Doorae 서버로부터 작업을 수신하고
+로컬 agent runtime에 위임합니다.
+
+## 아키텍처
+
+```mermaid
+graph TB
+    subgraph Cloud["Doorae 서버 (Cloud/Remote)"]
+        SERVER[Doorae Server]
+        WS[WebSocket Endpoint]
+        QUEUE[Task Queue]
+        SERVER --> WS
+        SERVER --> QUEUE
+    end
+
+    subgraph Machine1["개발자 머신 A"]
+        DAEMON1[Agent Daemon]
+        OH[OpenHands Runtime]
+        CLAUDE[Claude Agent SDK]
+        DAEMON1 -->|작업 위임| OH
+        DAEMON1 -->|작업 위임| CLAUDE
+    end
+
+    subgraph Machine2["개발자 머신 B"]
+        DAEMON2[Agent Daemon]
+        OH2[OpenHands Runtime]
+        CUSTOM[Custom Runtime]
+        DAEMON2 -->|작업 위임| OH2
+        DAEMON2 -->|작업 위임| CUSTOM
+    end
+
+    WS <-->|WebSocket| DAEMON1
+    WS <-->|WebSocket| DAEMON2
+```
+
+## 동작 흐름
+
+```mermaid
+sequenceDiagram
+    participant S as Doorae 서버
+    participant D as Agent Daemon
+    participant R as Agent Runtime
+
+    D->>S: WebSocket 연결 (인증)
+    S-->>D: 연결 확인 + 설정 동기화
+
+    loop 작업 수신 루프
+        S->>D: 작업 할당 (TaskAssignment)
+        D->>D: Runtime 선택 (라우팅)
+        D->>R: 작업 위임
+        R-->>D: 실행 결과 (스트리밍)
+        D-->>S: 결과 보고 (TaskResult)
+    end
+
+    Note over D: Heartbeat 주기적 전송
+    D->>S: Heartbeat (상태 + 리소스 정보)
+    S-->>D: Heartbeat ACK
+```
+
+## 핵심 구성 요소
+
+### 1. Daemon Process
+
+데몬은 시스템 서비스 또는 사용자 프로세스로 실행됩니다.
+
+```bash
+# 설치 및 실행 (계획)
+doorae daemon start --server wss://your-doorae-server.com
+doorae daemon status
+doorae daemon stop
+```
+
+!!! info "설정 파일"
+    데몬 설정은 `~/.doorae/daemon.yaml` 또는 프로젝트의 `.doorae/daemon.yaml`에서 관리됩니다.
+
+```yaml
+# daemon.yaml (계획)
+server:
+  url: "wss://your-doorae-server.com"
+  token: "${DOORAE_TOKEN}"
+  reconnect_interval: 5s
+
+runtimes:
+  openhands:
+    enabled: true
+    workspace: "/home/user/projects"
+    max_concurrent: 2
+  claude-agent-sdk:
+    enabled: true
+    api_key: "${ANTHROPIC_API_KEY}"
+    max_concurrent: 1
+
+resources:
+  max_memory: "4GB"
+  max_cpu_percent: 80
+```
+
+### 2. Runtime Abstraction Layer
+
+각 agent runtime은 공통 인터페이스를 구현합니다.
+
+```python
+# 계획된 인터페이스 (예시)
+class AgentRuntime(Protocol):
+    """Agent runtime 추상 인터페이스."""
+
+    async def execute(self, task: TaskAssignment) -> AsyncIterator[TaskEvent]:
+        """작업을 실행하고 이벤트를 스트리밍합니다."""
+        ...
+
+    async def cancel(self, task_id: str) -> None:
+        """실행 중인 작업을 취소합니다."""
+        ...
+
+    def capabilities(self) -> RuntimeCapabilities:
+        """이 runtime이 지원하는 기능 목록을 반환합니다."""
+        ...
+```
+
+### 3. Task Router
+
+수신된 작업의 특성에 따라 최적의 runtime을 선택합니다.
+
+| 작업 유형 | 우선 Runtime | 대체 Runtime |
+|----------|-------------|-------------|
+| 코드 작성/수정 | OpenHands | Claude Agent SDK |
+| 코드 리뷰 | Claude Agent SDK | OpenHands |
+| 테스트 실행 | OpenHands | - |
+| 문서 작성 | Claude Agent SDK | OpenHands |
+
+## 주요 이점
+
+### Multi-Machine 지원
+
+```mermaid
+graph LR
+    SERVER[Doorae 서버]
+    SERVER <--> D1[데몬 A<br/>GPU 서버]
+    SERVER <--> D2[데몬 B<br/>개발 노트북]
+    SERVER <--> D3[데몬 C<br/>CI/CD 러너]
+```
+
+여러 머신에서 데몬을 실행하여 **분산 작업 처리**가 가능합니다.
+GPU가 필요한 작업은 GPU 서버로, 로컬 파일 접근이 필요한 작업은 개발 머신으로 라우팅됩니다.
+
+### Runtime 추상화
+
+특정 agent runtime에 종속되지 않습니다.
+새로운 오픈소스 runtime이 등장하면 어댑터만 추가하여 지원할 수 있습니다.
+
+### Always-On 기능
+
+데몬은 백그라운드에서 상시 실행되므로, 사용자가 직접 CLI를 열지 않아도
+Doorae 서버에서 작업을 할당받아 자동으로 처리합니다.
+
+- 야간 코드 리뷰 자동 처리
+- CI 실패 시 자동 수정 시도
+- 정기적인 코드 품질 점검
+
+### 보안 모델
+
+!!! note "보안 고려사항"
+    데몬은 로컬 머신에서 코드를 실행하므로 보안이 중요합니다.
+
+- **인증**: Doorae 서버와의 WebSocket 연결은 JWT 토큰 기반 인증
+- **권한 제어**: 데몬별로 허용된 작업 유형과 리소스 제한 설정
+- **샌드박싱**: Agent runtime은 격리된 환경(Docker 컨테이너 등)에서 실행
+- **감사 로그**: 모든 작업 실행 내역을 로컬 및 서버에 기록
+
+## 관련 로드맵
+
+- [Multi-Machine 지원](multi-machine.md) - 여러 머신에서의 agent 실행
+- [Multi-Runtime 지원](multi-runtime.md) - 다양한 agent runtime 통합
+- [Always-On Agents](always-on-agents.md) - 상시 실행 agent 기능

--- a/docs/roadmap/persistent-memory.md
+++ b/docs/roadmap/persistent-memory.md
@@ -1,0 +1,156 @@
+# 에이전트 영속 메모리
+
+!!! warning "계획된 기능 (미구현)"
+    이 문서는 아직 구현되지 않은 기능의 설계 제안서입니다. 실제 구현은 설계와 다를 수 있으며, 커뮤니티 피드백을 바탕으로 변경될 수 있습니다.
+
+## 동기
+
+현재 Doorae 에이전트의 메모리는 **단일 세션**에 한정됩니다. 회의가 끝나면 에이전트는 대화 내용을 잊어버리고, 다음 회의에서 처음부터 다시 시작합니다. `langmem`을 통한 대화 요약 기능이 있지만, 이는 세션 내 컨텍스트 윈도우 관리를 위한 것이지 세션 간 기억 유지를 위한 것이 아닙니다.
+
+실제 팀원은 지난 회의에서 논의된 내용, 과거의 의사결정, 프로젝트의 히스토리를 기억합니다. 에이전트도 마찬가지여야 합니다.
+
+## 2-Layer 메모리 아키텍처
+
+에이전트 영속 메모리는 **서버 DB 계층**과 **에이전트 워크스페이스 계층**, 두 가지 계층으로 구성됩니다.
+
+```mermaid
+graph TB
+    subgraph Layer1["Layer 1: 서버 DB (구조화된 데이터)"]
+        Conversations["대화 기록"]
+        Tasks["Task 히스토리"]
+        Decisions["의사결정 로그"]
+        AgentMeta["에이전트 메타데이터"]
+    end
+
+    subgraph Layer2["Layer 2: 에이전트 워크스페이스 (비구조화된 데이터)"]
+        Memory["MEMORY.md"]
+        Notes["notes/"]
+        Snippets["snippets/"]
+        Preferences["preferences.yaml"]
+    end
+
+    subgraph Agent["에이전트 런타임"]
+        Retriever["Memory Retriever"]
+        Writer["Memory Writer"]
+    end
+
+    Agent --> Layer1
+    Agent --> Layer2
+    Retriever --> Conversations
+    Retriever --> Memory
+    Writer --> Decisions
+    Writer --> Notes
+```
+
+### Layer 1: 서버 DB (구조화된 데이터)
+
+서버가 관리하는 중앙 데이터베이스에 저장되는 구조화된 정보입니다.
+
+| 데이터 | 설명 | 예시 |
+|--------|------|------|
+| **대화 기록** | 채널/회의의 메시지 히스토리 | "3월 15일 스프린트 회의에서 API v2 설계를 확정함" |
+| **Task 히스토리** | 작업의 생성, 할당, 완료 이력 | "AUTH-42: OAuth 구현, Backend에게 할당, 완료" |
+| **의사결정 로그** | 회의에서 내린 의사결정과 근거 | "PostgreSQL 채택: 이유 — JSON 지원, 확장성" |
+| **에이전트 메타데이터** | 에이전트의 학습된 선호도와 패턴 | "PM은 스프린트 리뷰 시 GitHub 이슈를 먼저 확인" |
+
+### Layer 2: 에이전트 워크스페이스 (비구조화된 데이터)
+
+각 에이전트가 자신만의 워크스페이스에 파일 형태로 관리하는 정보입니다.
+
+```
+.doorae/agents/{agent_name}/
+├── MEMORY.md           # 핵심 기억 (자동 + 수동 업데이트)
+├── notes/              # 주제별 노트
+│   ├── api-design.md
+│   └── sprint-42.md
+├── snippets/           # 자주 사용하는 코드/텍스트
+└── preferences.yaml    # 에이전트 개인 설정
+```
+
+**MEMORY.md 예시:**
+
+```markdown
+# PM Agent Memory
+
+## 프로젝트 컨텍스트
+- 현재 스프린트: Sprint 42 (3/18 ~ 3/31)
+- 팀 크기: Backend 2, Frontend 1, DevOps 1
+
+## 주요 의사결정
+- 2026-03-15: API v2는 REST 유지, GraphQL은 Phase 2
+- 2026-03-10: 인증 시스템 OAuth2 + JWT 조합 채택
+
+## 진행 중인 이슈
+- #142: 로그인 속도 개선 (Backend 담당)
+- #155: 대시보드 리디자인 (Frontend 담당)
+```
+
+## 메모리 생명주기
+
+```mermaid
+sequenceDiagram
+    participant Meeting as 회의/채널
+    participant Agent as 에이전트
+    participant Retriever as Memory Retriever
+    participant DB as 서버 DB
+    participant WS as 워크스페이스
+
+    Note over Meeting,WS: 세션 시작
+
+    Agent->>Retriever: 관련 기억 요청
+    Retriever->>DB: 최근 대화/결정 조회
+    Retriever->>WS: MEMORY.md + 관련 notes 읽기
+    Retriever-->>Agent: 컨텍스트 주입
+
+    Note over Meeting,WS: 세션 진행 중
+
+    Meeting->>Agent: 새 메시지/이벤트
+    Agent->>Agent: 중요도 판단
+    Agent->>DB: 대화 기록 저장
+    Agent->>WS: MEMORY.md 업데이트 (중요 사항만)
+
+    Note over Meeting,WS: 세션 종료
+
+    Agent->>DB: 세션 요약 저장
+    Agent->>WS: notes/ 업데이트
+    Agent->>WS: 의사결정 로그 추가
+```
+
+## 메모리 검색 전략
+
+에이전트가 과거 기억을 검색할 때, 다음 전략을 조합합니다:
+
+| 전략 | 설명 | 활용 시나리오 |
+|------|------|--------------|
+| **시간 기반** | 최근 N일/N세션의 기록 | "지난 회의에서 뭘 논의했지?" |
+| **키워드 기반** | 특정 주제/이름으로 검색 | "OAuth 관련 결정 사항은?" |
+| **의미 기반** | 벡터 유사도 검색 | "비슷한 문제를 겪은 적이 있나?" |
+| **관계 기반** | 에이전트/Task/채널 연결 | "Backend가 담당했던 작업들은?" |
+
+## 디자인 참고
+
+최근 에이전트 시스템에서 널리 쓰이는 메모리 패턴을 참고합니다:
+
+- **자동 메모리 추출**: 대화에서 중요한 정보를 자동으로 식별하고 저장
+- **컨텍스트 주입**: 새 세션 시작 시 관련 기억을 시스템 프롬프트에 자동 포함
+- **메모리 편집**: 사용자가 에이전트의 기억을 직접 수정하거나 삭제 가능
+
+Doorae의 차별점은 **2-Layer 구조**를 통해 구조화된 DB와 비구조화된 파일을 동시에 활용하는 것입니다.
+
+## 외부 런타임 메모리 시스템과의 통합
+
+멀티 런타임 환경에서 각 런타임의 기존 메모리 시스템과 Doorae 메모리를 연동합니다:
+
+| 런타임 | 기존 메모리 시스템 | Doorae 통합 방식 |
+|--------|-------------------|-----------------|
+| **LangGraph** | `langmem` 인라인 요약 | DB Layer로 요약 결과 저장 |
+| **OpenHands** | 세션 히스토리 | workspace 파일 동기화 |
+| **Claude Agent SDK** | 대화 컨텍스트 | MEMORY.md 기반 컨텍스트 주입 |
+
+## 구현 고려사항
+
+- **저장소**: Layer 1은 SQLite → PostgreSQL, Layer 2는 로컬 파일시스템
+- **메모리 크기 관리**: MEMORY.md는 최대 크기 제한, 오래된 기억은 자동 아카이브
+- **프라이버시**: 에이전트 간 메모리 공유 범위를 설정 가능 (public / team / private)
+- **버전 관리**: workspace 파일은 git으로 히스토리 추적 가능
+- **기존 `langmem` 활용**: 현재 대화 요약 기능을 영속 메모리의 기반으로 확장

--- a/docs/roadmap/web-ui.md
+++ b/docs/roadmap/web-ui.md
@@ -1,0 +1,117 @@
+# Web UI
+
+!!! warning "계획된 기능 (미구현)"
+    이 문서는 아직 구현되지 않은 기능의 설계 제안서입니다. 실제 구현은 설계와 다를 수 있으며, 커뮤니티 피드백을 바탕으로 변경될 수 있습니다.
+
+## 동기
+
+현재 Doorae는 CLI와 TUI(Textual 기반)를 통해 터미널에서 동작합니다. 이 인터페이스는 개발자에게 친숙하지만, 다음과 같은 한계가 있습니다:
+
+- **접근성**: 터미널에 익숙하지 않은 팀원은 참여하기 어려움
+- **시각적 표현**: 에이전트 상태, Task 진행 상황, 대화 히스토리를 직관적으로 파악하기 어려움
+- **동시 작업**: 여러 채널과 회의를 동시에 모니터링하기 어려움
+- **모바일 접근**: 터미널 UI로는 모바일 환경에서 사용 불가
+
+Web UI는 이러한 한계를 극복하고, Doorae의 모든 기능을 **직관적인 웹 인터페이스**로 제공합니다.
+
+## 핵심 화면 구성
+
+```mermaid
+graph TB
+    subgraph WebUI["Web UI 레이아웃"]
+        direction LR
+        subgraph Sidebar["사이드바"]
+            ChannelList["채널 목록"]
+            AgentList["에이전트 상태"]
+            Settings["설정"]
+        end
+
+        subgraph Main["메인 영역"]
+            ChatView["채팅 뷰"]
+            MeetingView["회의 뷰"]
+            TaskBoard["Task Board"]
+        end
+
+        subgraph Detail["상세 패널"]
+            AgentDetail["에이전트 상세"]
+            TaskDetail["Task 상세"]
+            ThreadView["스레드 뷰"]
+        end
+    end
+```
+
+### 주요 뷰
+
+| 뷰 | 설명 |
+|----|------|
+| **채널 목록** | 참여 중인 채널, 읽지 않은 메시지 수, 활성 회의 표시 |
+| **채팅 뷰** | 메시지 타임라인, 스레드, @mention 입력, 에이전트 응답 스트리밍 |
+| **회의 뷰** | 안건 진행 상황, 발언자 큐, 실시간 타이머, 회의 요약 |
+| **에이전트 관리** | 에이전트 목록, 상태(active/idle/sleeping), 역할/전문성 편집 |
+| **Task Board** | Kanban 보드, 드래그 앤 드롭, 에이전트 할당, 진행률 |
+
+## 실시간 WebSocket 통합
+
+Web UI는 기존 Doorae 서버의 WebSocket 아키텍처를 확장하여 실시간 통신을 구현합니다.
+
+```mermaid
+sequenceDiagram
+    participant Browser as Web Browser
+    participant Server as Doorae Server
+    participant Agent as Agent Runtime
+
+    Browser->>Server: WebSocket 연결 (/ws/channel/{id})
+    Server-->>Browser: 연결 확인 + 초기 상태
+
+    Agent->>Server: 메시지 전송
+    Server-->>Browser: 실시간 메시지 푸시
+
+    Browser->>Server: 사용자 메시지 전송
+    Server->>Agent: @mention 에이전트 활성화
+    Agent-->>Server: 스트리밍 응답 (token by token)
+    Server-->>Browser: 스트리밍 토큰 전달
+
+    Note over Browser,Agent: 에이전트 응답이 실시간으로<br/>타이핑되는 것처럼 표시
+```
+
+### 주요 WebSocket 이벤트
+
+| 이벤트 | 방향 | 설명 |
+|--------|------|------|
+| `message.new` | Server → Client | 새 메시지 도착 |
+| `message.send` | Client → Server | 사용자 메시지 전송 |
+| `agent.stream_token` | Server → Client | 에이전트 응답 스트리밍 |
+| `agent.status_change` | Server → Client | 에이전트 상태 변경 (idle → speaking 등) |
+| `meeting.agenda_update` | Server → Client | 안건 상태 변경 |
+| `task.update` | Server → Client | Task 상태 변경 |
+
+## 기술 스택 (안)
+
+| 계층 | 기술 | 선정 이유 |
+|------|------|-----------|
+| **Framework** | React 18+ | 컴포넌트 기반 UI, 풍부한 생태계 |
+| **상태 관리** | Zustand | 경량, WebSocket 상태 관리에 적합 |
+| **스타일링** | Tailwind CSS | 빠른 프로토타이핑, 일관된 디자인 시스템 |
+| **실시간 통신** | Native WebSocket | 기존 서버 프로토콜과 호환 |
+| **빌드** | Vite | 빠른 HMR, 간결한 설정 |
+| **타입 안전** | TypeScript | API 타입 공유, 런타임 에러 감소 |
+
+## 디자인 참고
+
+기존 에이전트 채팅 UI 패턴을 참고하되, Doorae만의 차별점을 추가합니다:
+
+| 요소 | 일반적인 단일 에이전트 UI | Doorae Web UI (계획) |
+|------|---------------------------|---------------------|
+| 에이전트 대화 | 단일 에이전트 채팅 | 다중 에이전트 채널 대화 |
+| 작업 추적 | 에이전트 내부 Task | 공유 Task Board |
+| 회의 모드 | 없음 | 채널 내 구조화된 회의 모드 |
+| 위임 시각화 | 없음 | TechLead → Backend 위임 흐름 표시 |
+| 에이전트 상태 | 단일 상태 | idle / speaking / tool_calling / sleeping |
+
+## 구현 고려사항
+
+- **점진적 구현**: 채팅 뷰 → 에이전트 관리 → 회의 뷰 → Task Board 순서로 개발
+- **API 우선**: REST + WebSocket API를 먼저 정의하고, 프론트엔드는 API 위에 구축
+- **기존 서버 확장**: 현재 FastAPI 서버(`doorae/server/`)의 라우트를 확장
+- **반응형 디자인**: 데스크톱 우선, 태블릿/모바일 대응
+- **접근성**: WCAG 2.1 AA 준수, 키보드 내비게이션, 스크린 리더 지원


### PR DESCRIPTION
## Summary
- add roadmap docs for agent daemon bridge, web UI, and persistent memory
- replace vendor-specific references with neutral pattern-based wording
- keep the content framed as planned roadmap items

## Notes
- this PR intentionally includes only the three roadmap docs staged on this branch
- other local documentation restructuring in the working tree is not included